### PR TITLE
feat: dual-mode integration tests (pre-built image or build from source)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,21 +38,20 @@ jobs:
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2
 
+      - name: Setup Testcontainers Cloud Client
+        uses: atomicjar/testcontainers-cloud-setup-action@v1
+        with:
+          token: ${{ secrets.TC_CLOUD_TOKEN }}
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: '--allowed-tools Bash(make:*),Bash(go mod tidy),Bash(git fetch *),Bash(git pull *)'
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ mcp-anything is a stateless Go proxy that converts HTTP REST APIs into MCP (Mode
 Full design: SPEC.md
 
 ## Module
-github.com/your-org/mcp-anything
+github.com/gaarutyunov/mcp-anything
 
 ## Commands
 
@@ -21,14 +21,24 @@ make vet          # go vet ./...
 ### Unit tests (must pass before every commit)
 make test         # go test -race -count=1 ./...
 
-### Integration tests (require Docker + TC_CLOUD_TOKEN env var)
-make integration  # go test -tags integration -race -count=1 -timeout 300s ./...
+### Integration tests (require Docker)
+make integration  # go test -tags integration ... ./tests/integration/...
+
+Without `PROXY_IMAGE`, tests build the proxy from source using the Dockerfile. Set `PROXY_IMAGE` to test against a pre-built image (used in CI).
 
 ### All checks (run before every commit)
 make check        # runs lint + vet + test + build in sequence
 
 ## Pre-commit checklist
-Run `make check` and fix all failures before committing. Never commit with failing lint, vet, or unit tests. Integration tests are run in CI but should also pass locally if Docker is available.
+1. Run `make check` and fix all failures before committing.
+2. Run `make integration` and fix all failures before committing.
+
+Never commit with failing lint, vet, unit tests, or integration tests.
+
+## Integration tests
+Integration tests live in `tests/integration/` with build tag `//go:build integration`. They run the proxy as a Docker container alongside test fixtures (WireMock, etc.) using Testcontainers. They do NOT import internal packages — they test the built image end-to-end via HTTP and MCP protocol.
+
+**You MUST run `make integration` after implementing any feature or fix and ensure all integration tests pass.** If an integration test fails, diagnose and fix the issue before committing. Do not skip or ignore integration test failures.
 
 ## Code conventions
 - All errors must be wrapped with context: `fmt.Errorf("loading spec: %w", err)`
@@ -38,7 +48,6 @@ Run `make check` and fix all failures before committing. Never commit with faili
 - Interfaces are defined in the package that uses them, not the package that implements them
 - Use `context.Context` as the first argument in all functions that do I/O or call other services
 - All config fields that reference secrets use `${ENV_VAR}` syntax; never log expanded values
-- Integration tests live in files named `*_integration_test.go` with build tag `//go:build integration`
 - Unit tests live in files named `*_test.go` with no build tag
 
 ## Testcontainers

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ See [SPEC.md](SPEC.md) for the full architecture and design decisions.
 (To be filled in when the MVP proxy is working — see TASK-03)
 
 ## Development
-Requirements: Go 1.23+, Docker (for integration tests)
+Requirements: Go 1.25+, Docker (for integration tests)
 
     make check        # lint + vet + unit tests + build
-    make integration  # integration tests (requires Docker)
+    make integration  # integration tests (builds from Dockerfile, or set PROXY_IMAGE)
 
-Set `TC_CLOUD_TOKEN` to run integration tests via Testcontainers Cloud.
+Set `TC_CLOUD_TOKEN` to run containers via Testcontainers Cloud.

--- a/tests/integration/mvp_test.go
+++ b/tests/integration/mvp_test.go
@@ -21,13 +21,18 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-const defaultProxyImage = "ghcr.io/gaarutyunov/mcp-anything:dev"
-
-func proxyImage() string {
-	if v := os.Getenv("PROXY_IMAGE"); v != "" {
-		return v
+// proxyContainerRequest returns a ContainerRequest for the proxy.
+// If PROXY_IMAGE is set, it pulls that image. Otherwise, it builds from source using the Dockerfile.
+func proxyContainerRequest() testcontainers.ContainerRequest {
+	if img := os.Getenv("PROXY_IMAGE"); img != "" {
+		return testcontainers.ContainerRequest{Image: img}
 	}
-	return defaultProxyImage
+	return testcontainers.ContainerRequest{
+		FromDockerfile: testcontainers.FromDockerfile{
+			Context:    "../..",
+			Dockerfile: "Dockerfile",
+		},
+	}
 }
 
 const testOpenAPISpec = `openapi: "3.0.0"
@@ -146,20 +151,19 @@ upstreams:
 		t.Fatalf("write config file: %v", err)
 	}
 
-	// 4. Start the proxy container from the pre-built image.
-	proxy := startContainer(ctx, t, testcontainers.ContainerRequest{
-		Image:        proxyImage(),
-		ExposedPorts: []string{"8080/tcp"},
-		Networks:     []string{net.Name},
-		Env: map[string]string{
-			"CONFIG_PATH": "/etc/mcp-anything/config.yaml",
-		},
-		Files: []testcontainers.ContainerFile{
-			{HostFilePath: cfgPath, ContainerFilePath: "/etc/mcp-anything/config.yaml", FileMode: 0o644},
-			{HostFilePath: specPath, ContainerFilePath: "/etc/mcp-anything/spec.yaml", FileMode: 0o644},
-		},
-		WaitingFor: wait.ForHTTP("/healthz").WithPort("8080").WithStartupTimeout(60 * time.Second),
-	})
+	// 4. Start the proxy container (pre-built image via PROXY_IMAGE, or build from Dockerfile).
+	proxyReq := proxyContainerRequest()
+	proxyReq.ExposedPorts = []string{"8080/tcp"}
+	proxyReq.Networks = []string{net.Name}
+	proxyReq.Env = map[string]string{
+		"CONFIG_PATH": "/etc/mcp-anything/config.yaml",
+	}
+	proxyReq.Files = []testcontainers.ContainerFile{
+		{HostFilePath: cfgPath, ContainerFilePath: "/etc/mcp-anything/config.yaml", FileMode: 0o644},
+		{HostFilePath: specPath, ContainerFilePath: "/etc/mcp-anything/spec.yaml", FileMode: 0o644},
+	}
+	proxyReq.WaitingFor = wait.ForHTTP("/healthz").WithPort("8080").WithStartupTimeout(120 * time.Second)
+	proxy := startContainer(ctx, t, proxyReq)
 
 	proxyHost, err := proxy.Host(ctx)
 	if err != nil {
@@ -267,7 +271,10 @@ func startContainer(ctx context.Context, t *testing.T, req testcontainers.Contai
 }
 
 func containerName(req testcontainers.ContainerRequest) string {
-	return req.Image
+	if req.Image != "" {
+		return req.Image
+	}
+	return "Dockerfile"
 }
 
 func registerStub(t *testing.T, base, body string) {


### PR DESCRIPTION
## Summary
- Integration tests support two modes via `PROXY_IMAGE` env var:
  - **CI**: uses pre-built GHCR image from the `build-image` job
  - **Claude / local dev**: builds from `Dockerfile` via testcontainers `FromDockerfile` (no pre-built image needed)
- Claude workflow now has Go, golangci-lint, and Testcontainers Cloud set up so it can run `make integration` with build-from-source
- CLAUDE.md updated: requires running `make integration` before committing, fixes module path
- README.md: fix Go version requirement (1.25+)

## Test plan
- [ ] CI `integration-test` job passes using pre-built GHCR image
- [ ] Claude workflow can run `make integration` building from source via Testcontainers Cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Increased minimum Go version requirement to 1.25+
  - Updated integration testing guidance with support for pre-built container images

* **Tests**
  - Enhanced container startup reliability with extended health check timeout

* **Chores**
  - Updated workflow and module configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->