### PR TITLE
feat: TASK-11 Non-JSON response handling and error response transforms

### DIFF
--- a/internal/content/error.go
+++ b/internal/content/error.go
@@ -1,0 +1,80 @@
+package content
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/itchyny/gojq"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ProblemDetail represents an RFC 9457 problem+json response body.
+type ProblemDetail struct {
+	Type     string `json:"type"`
+	Title    string `json:"title"`
+	Status   int    `json:"status"`
+	Detail   string `json:"detail"`
+	Instance string `json:"instance"`
+}
+
+// ParseErrorBody parses an upstream error response body.
+// If contentType is application/problem+json, it returns a ProblemDetail as map[string]any.
+// Otherwise, it attempts JSON parse and returns the result, or falls back to raw string.
+func ParseErrorBody(body []byte, contentType string) any {
+	ct := strings.ToLower(strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0]))
+
+	if ct == "application/problem+json" {
+		var pd ProblemDetail
+		if err := json.Unmarshal(body, &pd); err == nil {
+			return map[string]any{
+				"type":     pd.Type,
+				"title":    pd.Title,
+				"status":   pd.Status,
+				"detail":   pd.Detail,
+				"instance": pd.Instance,
+			}
+		}
+	}
+
+	var result any
+	if err := json.Unmarshal(body, &result); err == nil {
+		return result
+	}
+
+	return string(body)
+}
+
+// ToErrorResult builds a CallToolResult with IsError: true by running the error transform.
+func ToErrorResult(
+	ctx context.Context,
+	body []byte,
+	contentType string,
+	statusCode int,
+	errorTransform *gojq.Code,
+) *sdkmcp.CallToolResult {
+	parsed := ParseErrorBody(body, contentType)
+
+	// Ensure status is set for map results.
+	if m, ok := parsed.(map[string]any); ok {
+		if m["status"] == nil {
+			m["status"] = statusCode
+		}
+	}
+
+	transformed, err := runOnce(ctx, errorTransform, parsed)
+	if err != nil {
+		transformed = map[string]any{
+			"error": fmt.Sprintf("upstream returned %d", statusCode),
+			"body":  string(body),
+		}
+	}
+
+	return &sdkmcp.CallToolResult{
+		IsError: true,
+		Content: []sdkmcp.Content{
+			&sdkmcp.TextContent{Text: marshalToString(transformed)},
+		},
+	}
+}

--- a/internal/content/format.go
+++ b/internal/content/format.go
@@ -1,0 +1,156 @@
+package content
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/itchyny/gojq"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Format represents the x-mcp-response-format extension value.
+type Format string
+
+// Response format constants for x-mcp-response-format.
+const (
+	FormatJSON   Format = "json"
+	FormatText   Format = "text"
+	FormatImage  Format = "image"
+	FormatAudio  Format = "audio"
+	FormatBinary Format = "binary"
+	FormatAuto   Format = "auto"
+)
+
+// Detect returns the effective format based on the configured format and
+// the actual Content-Type header from the upstream response.
+// If configured format is FormatAuto, it inspects contentType.
+// Otherwise it returns the configured format.
+func Detect(configured Format, contentType string) Format {
+	if configured != FormatAuto {
+		return configured
+	}
+	ct := strings.ToLower(strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0]))
+	switch {
+	case ct == "application/json" || strings.HasSuffix(ct, "+json"):
+		return FormatJSON
+	case strings.HasPrefix(ct, "text/"):
+		return FormatText
+	case strings.HasPrefix(ct, "image/"):
+		return FormatImage
+	case strings.HasPrefix(ct, "audio/"):
+		return FormatAudio
+	default:
+		return FormatBinary
+	}
+}
+
+// ToMCPContent converts a response body to the appropriate MCP content type.
+// For JSON and text formats, it returns TextContent.
+// For image, audio, binary formats, it returns the appropriate MCP content.
+// The responseTransform jq code is applied only for JSON and text formats.
+// For binary formats, body is passed as raw bytes (the SDK handles base64 encoding in JSON).
+func ToMCPContent(
+	ctx context.Context,
+	format Format,
+	body []byte,
+	contentType string,
+	responseTransform *gojq.Code,
+) ([]sdkmcp.Content, error) {
+	mimeType := stripMIMEParams(contentType)
+	switch format {
+	case FormatJSON:
+		var parsed any
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			return nil, fmt.Errorf("unmarshal JSON body: %w", err)
+		}
+		if responseTransform != nil {
+			transformed, err := runOnce(ctx, responseTransform, parsed)
+			if err != nil {
+				return nil, fmt.Errorf("response transform: %w", err)
+			}
+			parsed = transformed
+		}
+		return []sdkmcp.Content{&sdkmcp.TextContent{Text: marshalToString(parsed)}}, nil
+
+	case FormatText:
+		if responseTransform != nil {
+			transformed, err := runOnce(ctx, responseTransform, string(body))
+			if err != nil {
+				return nil, fmt.Errorf("response transform: %w", err)
+			}
+			return []sdkmcp.Content{&sdkmcp.TextContent{Text: marshalToString(transformed)}}, nil
+		}
+		return []sdkmcp.Content{&sdkmcp.TextContent{Text: string(body)}}, nil
+
+	case FormatImage:
+		return []sdkmcp.Content{&sdkmcp.ImageContent{Data: body, MIMEType: mimeType}}, nil
+
+	case FormatAudio:
+		return []sdkmcp.Content{&sdkmcp.AudioContent{Data: body, MIMEType: mimeType}}, nil
+
+	case FormatBinary:
+		return []sdkmcp.Content{&sdkmcp.EmbeddedResource{
+			Resource: &sdkmcp.ResourceContents{
+				MIMEType: mimeType,
+				Blob:     body,
+			},
+		}}, nil
+
+	case FormatAuto:
+		// FormatAuto should have been resolved by Detect before calling ToMCPContent.
+		// Fall back to JSON as a safe default.
+		return ToMCPContent(ctx, FormatJSON, body, contentType, responseTransform)
+	default:
+		return ToMCPContent(ctx, FormatJSON, body, contentType, responseTransform)
+	}
+}
+
+// stripMIMEParams removes parameters from a Content-Type header value (splits on ";").
+func stripMIMEParams(contentType string) string {
+	return strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0])
+}
+
+// marshalToString marshals v to a JSON string without HTML escaping,
+// or returns a string representation on error.
+func marshalToString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	// json.Encoder.Encode appends a newline; trim it.
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// runOnce runs a compiled jq expression and returns the first output value.
+// The iterator is fully drained to catch runtime errors that occur after the first value.
+func runOnce(ctx context.Context, code *gojq.Code, input any) (any, error) {
+	iter := code.RunWithContext(ctx, input)
+	var (
+		first any
+		have  bool
+	)
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			if !have {
+				return nil, fmt.Errorf("jq expression produced no output")
+			}
+			return first, nil
+		}
+		if err, isErr := v.(error); isErr {
+			return nil, fmt.Errorf("jq runtime error: %w", err)
+		}
+		if !have {
+			first = v
+			have = true
+		}
+	}
+}

--- a/internal/content/format_test.go
+++ b/internal/content/format_test.go
@@ -1,0 +1,334 @@
+package content
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/itchyny/gojq"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configured Format
+		ctHeader   string
+		want       Format
+	}{
+		{name: "auto json", configured: FormatAuto, ctHeader: "application/json", want: FormatJSON},
+		{name: "auto json with params", configured: FormatAuto, ctHeader: "application/json; charset=utf-8", want: FormatJSON},
+		{name: "auto problem json", configured: FormatAuto, ctHeader: "application/problem+json", want: FormatJSON},
+		{name: "auto fhir json", configured: FormatAuto, ctHeader: "application/fhir+json", want: FormatJSON},
+		{name: "auto pdf", configured: FormatAuto, ctHeader: "application/pdf", want: FormatBinary},
+		{name: "auto octet stream", configured: FormatAuto, ctHeader: "application/octet-stream", want: FormatBinary},
+		{name: "auto png", configured: FormatAuto, ctHeader: "image/png", want: FormatImage},
+		{name: "auto jpeg", configured: FormatAuto, ctHeader: "image/jpeg", want: FormatImage},
+		{name: "auto mp3", configured: FormatAuto, ctHeader: "audio/mp3", want: FormatAudio},
+		{name: "auto mpeg audio", configured: FormatAuto, ctHeader: "audio/mpeg", want: FormatAudio},
+		{name: "auto text plain", configured: FormatAuto, ctHeader: "text/plain", want: FormatText},
+		{name: "auto text html", configured: FormatAuto, ctHeader: "text/html", want: FormatText},
+		// Explicit overrides auto-detection.
+		{name: "explicit image overrides json ct", configured: FormatImage, ctHeader: "application/json", want: FormatImage},
+		{name: "explicit text overrides binary ct", configured: FormatText, ctHeader: "application/octet-stream", want: FormatText},
+		{name: "explicit json overrides image ct", configured: FormatJSON, ctHeader: "image/png", want: FormatJSON},
+		{name: "explicit binary stays binary", configured: FormatBinary, ctHeader: "text/plain", want: FormatBinary},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Detect(tc.configured, tc.ctHeader)
+			if got != tc.want {
+				t.Errorf("Detect(%q, %q) = %q, want %q", tc.configured, tc.ctHeader, got, tc.want)
+			}
+		})
+	}
+}
+
+func compileJq(t *testing.T, expr string) *gojq.Code {
+	t.Helper()
+	q, err := gojq.Parse(expr)
+	if err != nil {
+		t.Fatalf("parse jq %q: %v", expr, err)
+	}
+	code, err := gojq.Compile(q)
+	if err != nil {
+		t.Fatalf("compile jq %q: %v", expr, err)
+	}
+	return code
+}
+
+func TestToMCPContent_JSON(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	body := []byte(`{"name":"Fido","species":"dog"}`)
+	identity := compileJq(t, ".")
+
+	contents, err := ToMCPContent(ctx, FormatJSON, body, "application/json", identity)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(contents) != 1 {
+		t.Fatalf("expected 1 content, got %d", len(contents))
+	}
+	tc, ok := contents[0].(*sdkmcp.TextContent)
+	if !ok {
+		t.Fatalf("expected *TextContent, got %T", contents[0])
+	}
+	if !strings.Contains(tc.Text, "Fido") {
+		t.Errorf("expected Fido in text, got: %s", tc.Text)
+	}
+}
+
+func TestToMCPContent_JSONTransform(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	body := []byte(`{"name":"Fido","species":"dog"}`)
+	xform := compileJq(t, "{pet: .name}")
+
+	contents, err := ToMCPContent(ctx, FormatJSON, body, "application/json", xform)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tc := contents[0].(*sdkmcp.TextContent)
+	if !strings.Contains(tc.Text, "pet") || !strings.Contains(tc.Text, "Fido") {
+		t.Errorf("unexpected text: %s", tc.Text)
+	}
+	if strings.Contains(tc.Text, "species") {
+		t.Errorf("species should be filtered out: %s", tc.Text)
+	}
+}
+
+func TestToMCPContent_Text(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	body := []byte("hello world")
+	contents, err := ToMCPContent(ctx, FormatText, body, "text/plain", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tc := contents[0].(*sdkmcp.TextContent)
+	if tc.Text != "hello world" {
+		t.Errorf("expected 'hello world', got %q", tc.Text)
+	}
+}
+
+func TestToMCPContent_TextWithTransform(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	body := []byte("hello")
+	xform := compileJq(t, `"got: " + .`)
+
+	contents, err := ToMCPContent(ctx, FormatText, body, "text/plain", xform)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tc := contents[0].(*sdkmcp.TextContent)
+	if tc.Text != "got: hello" {
+		t.Errorf("expected 'got: hello', got %q", tc.Text)
+	}
+}
+
+func TestToMCPContent_Image(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	body := []byte{0x89, 0x50, 0x4e, 0x47} // PNG header bytes
+	contents, err := ToMCPContent(ctx, FormatImage, body, "image/png", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ic, ok := contents[0].(*sdkmcp.ImageContent)
+	if !ok {
+		t.Fatalf("expected *ImageContent, got %T", contents[0])
+	}
+	if ic.MIMEType != "image/png" {
+		t.Errorf("expected image/png, got %s", ic.MIMEType)
+	}
+	if len(ic.Data) == 0 {
+		t.Error("expected non-empty image data")
+	}
+}
+
+func TestToMCPContent_Audio(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	body := []byte{0x49, 0x44, 0x33} // ID3 header bytes
+	contents, err := ToMCPContent(ctx, FormatAudio, body, "audio/mpeg", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ac, ok := contents[0].(*sdkmcp.AudioContent)
+	if !ok {
+		t.Fatalf("expected *AudioContent, got %T", contents[0])
+	}
+	if ac.MIMEType != "audio/mpeg" {
+		t.Errorf("expected audio/mpeg, got %s", ac.MIMEType)
+	}
+	if len(ac.Data) == 0 {
+		t.Error("expected non-empty audio data")
+	}
+}
+
+func TestToMCPContent_Binary(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	body := []byte{0x25, 0x50, 0x44, 0x46} // %PDF header
+	contents, err := ToMCPContent(ctx, FormatBinary, body, "application/pdf", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	er, ok := contents[0].(*sdkmcp.EmbeddedResource)
+	if !ok {
+		t.Fatalf("expected *EmbeddedResource, got %T", contents[0])
+	}
+	if er.Resource == nil {
+		t.Fatal("expected non-nil Resource")
+	}
+	if er.Resource.MIMEType != "application/pdf" {
+		t.Errorf("expected application/pdf, got %s", er.Resource.MIMEType)
+	}
+	if len(er.Resource.Blob) == 0 {
+		t.Error("expected non-empty blob")
+	}
+}
+
+func TestToMCPContent_MIMEParamsStripped(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	body := []byte{0x01, 0x02}
+	contents, err := ToMCPContent(ctx, FormatImage, body, "image/png; charset=utf-8", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ic := contents[0].(*sdkmcp.ImageContent)
+	if ic.MIMEType != "image/png" {
+		t.Errorf("expected stripped mime 'image/png', got %q", ic.MIMEType)
+	}
+}
+
+// ParseErrorBody tests
+
+func TestParseErrorBody_ProblemJSON(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"type":"urn:example:error","title":"Not Found","status":404,"detail":"item missing","instance":"/items/1"}`)
+	result := ParseErrorBody(body, "application/problem+json")
+
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", result)
+	}
+	if m["title"] != "Not Found" {
+		t.Errorf("expected title 'Not Found', got %v", m["title"])
+	}
+	if m["detail"] != "item missing" {
+		t.Errorf("expected detail 'item missing', got %v", m["detail"])
+	}
+	if m["status"] != 404 {
+		t.Errorf("expected status 404, got %v", m["status"])
+	}
+}
+
+func TestParseErrorBody_ProblemJSONWithParams(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"title":"Bad Request","status":400}`)
+	result := ParseErrorBody(body, "application/problem+json; charset=utf-8")
+
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", result)
+	}
+	if m["title"] != "Bad Request" {
+		t.Errorf("expected 'Bad Request', got %v", m["title"])
+	}
+}
+
+func TestParseErrorBody_RegularJSON(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"error":"forbidden","code":403}`)
+	result := ParseErrorBody(body, "application/json")
+
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", result)
+	}
+	if m["error"] != "forbidden" {
+		t.Errorf("expected 'forbidden', got %v", m["error"])
+	}
+}
+
+func TestParseErrorBody_PlainText(t *testing.T) {
+	t.Parallel()
+
+	body := []byte("Internal Server Error")
+	result := ParseErrorBody(body, "text/plain")
+
+	s, ok := result.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", result)
+	}
+	if s != "Internal Server Error" {
+		t.Errorf("expected 'Internal Server Error', got %q", s)
+	}
+}
+
+func TestParseErrorBody_NonJSONFallback(t *testing.T) {
+	t.Parallel()
+
+	body := []byte("not valid json {{{")
+	result := ParseErrorBody(body, "application/json")
+
+	s, ok := result.(string)
+	if !ok {
+		t.Fatalf("expected string fallback, got %T", result)
+	}
+	if s != "not valid json {{{" {
+		t.Errorf("expected raw string, got %q", s)
+	}
+}
+
+func TestToErrorResult_ProblemJSON(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	body := []byte(`{"title":"Invalid order","status":422,"detail":"quantity must be > 0"}`)
+	errTransform := compileJq(t, `if .title then {error: .title, detail: (.detail // ""), status: (.status // 0)} else {error: ("upstream error: HTTP " + (if .status then (.status | tostring) else "unknown" end)), body: .} end`)
+
+	result := ToErrorResult(ctx, body, "application/problem+json", 422, errTransform)
+
+	if !result.IsError {
+		t.Error("expected IsError=true")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected non-empty content")
+	}
+	tc, ok := result.Content[0].(*sdkmcp.TextContent)
+	if !ok {
+		t.Fatalf("expected *TextContent, got %T", result.Content[0])
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(tc.Text), &out); err != nil {
+		t.Fatalf("unmarshal result: %v\ntext: %s", err, tc.Text)
+	}
+	if out["error"] != "Invalid order" {
+		t.Errorf("expected error='Invalid order', got %v", out["error"])
+	}
+	if out["detail"] != "quantity must be > 0" {
+		t.Errorf("expected detail='quantity must be > 0', got %v", out["detail"])
+	}
+}

--- a/internal/transform/request.go
+++ b/internal/transform/request.go
@@ -13,9 +13,9 @@ const DefaultResponseExpr = "."
 
 // DefaultErrorExpr is the default error transform that handles problem+json and generic errors.
 const DefaultErrorExpr = `if .title then
-  {error: .title, detail: (.detail // ""), status: .status}
+  {error: .title, detail: (.detail // ""), status: (.status // 0)}
 else
-  {error: ("upstream error: HTTP " + (.status // "unknown" | tostring)), body: .}
+  {error: ("upstream error: HTTP " + (if .status then (.status | tostring) else "unknown" end)), body: .}
 end`
 
 // GenerateRequestJq generates a jq expression string from OpenAPI operation metadata.

--- a/internal/upstream/registry.go
+++ b/internal/upstream/registry.go
@@ -17,6 +17,7 @@ import (
 
 	outboundauth "github.com/gaarutyunov/mcp-anything/internal/auth/outbound"
 	"github.com/gaarutyunov/mcp-anything/internal/config"
+	"github.com/gaarutyunov/mcp-anything/internal/content"
 	"github.com/gaarutyunov/mcp-anything/internal/openapi"
 	"github.com/gaarutyunov/mcp-anything/internal/transform"
 )
@@ -248,8 +249,10 @@ func (r *Registry) handleToolCall(ctx context.Context, entry *RegistryEntry, arg
 		}, nil
 	}
 
+	contentType := resp.Header.Get("Content-Type")
+
 	if inError {
-		return buildErrorResult(ctx, entry.Transforms, resp.StatusCode, body), nil
+		return buildErrorResult(ctx, entry.Transforms, resp.StatusCode, contentType, body), nil
 	}
 
 	// Success path: validate response if configured.
@@ -267,7 +270,7 @@ func (r *Registry) handleToolCall(ctx context.Context, entry *RegistryEntry, arg
 		}
 	}
 
-	return buildSuccessResult(ctx, entry.Transforms, body), nil
+	return buildSuccessResult(ctx, entry.Transforms, entry.ResponseFormat, contentType, body), nil
 }
 
 // newErrorResult creates an IsError CallToolResult with the given message.
@@ -281,55 +284,23 @@ func newErrorResult(msg string) *sdkmcp.CallToolResult {
 }
 
 // buildErrorResult transforms an error response body and returns an error CallToolResult.
-func buildErrorResult(ctx context.Context, transforms *transform.CompiledTransforms, statusCode int, body []byte) *sdkmcp.CallToolResult {
-	var parsed any
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		parsed = map[string]any{"status": statusCode, "body": string(body)}
-	} else if m, ok := parsed.(map[string]any); ok {
-		if m["status"] == nil {
-			m["status"] = statusCode
-		}
-	} else {
-		parsed = map[string]any{"status": statusCode, "body": parsed}
-	}
-
-	transformed, err := transforms.RunError(ctx, parsed)
-	if err != nil {
-		slog.Warn("error transform failed, using raw body", "error", err)
-		transformed = map[string]any{"error": fmt.Sprintf("upstream returned %d", statusCode), "body": string(body)}
-	}
-
-	return &sdkmcp.CallToolResult{
-		IsError: true,
-		Content: []sdkmcp.Content{
-			&sdkmcp.TextContent{Text: marshalToString(transformed)},
-		},
-	}
+func buildErrorResult(ctx context.Context, transforms *transform.CompiledTransforms, statusCode int, contentType string, body []byte) *sdkmcp.CallToolResult {
+	return content.ToErrorResult(ctx, body, contentType, statusCode, transforms.Error)
 }
 
-// buildSuccessResult transforms a success response body and returns a CallToolResult.
-func buildSuccessResult(ctx context.Context, transforms *transform.CompiledTransforms, body []byte) *sdkmcp.CallToolResult {
-	var parsed any = string(body)
-	var jsonParsed any
-	if err := json.Unmarshal(body, &jsonParsed); err == nil {
-		parsed = jsonParsed
-	}
-
-	transformed, err := transforms.RunResponse(ctx, parsed)
+// buildSuccessResult converts a success response body to MCP content and returns a CallToolResult.
+func buildSuccessResult(ctx context.Context, transforms *transform.CompiledTransforms, responseFormat, contentType string, body []byte) *sdkmcp.CallToolResult {
+	format := content.Detect(content.Format(responseFormat), contentType)
+	contents, err := content.ToMCPContent(ctx, format, body, contentType, transforms.Response)
 	if err != nil {
-		slog.Warn("response transform failed, using raw body", "error", err)
+		slog.Warn("response content conversion failed, using raw body", "error", err)
 		return &sdkmcp.CallToolResult{
 			Content: []sdkmcp.Content{
 				&sdkmcp.TextContent{Text: string(body)},
 			},
 		}
 	}
-
-	return &sdkmcp.CallToolResult{
-		Content: []sdkmcp.Content{
-			&sdkmcp.TextContent{Text: marshalToString(transformed)},
-		},
-	}
+	return &sdkmcp.CallToolResult{Content: contents}
 }
 
 // buildUpstreamURL constructs the upstream URL using the request envelope.
@@ -355,18 +326,6 @@ func buildUpstreamURL(baseURL, pathTemplate string, envelope *transform.RequestE
 	}
 
 	return u.String(), nil
-}
-
-// marshalToString marshals v to a JSON string, or returns a string representation on error.
-func marshalToString(v any) string {
-	if s, ok := v.(string); ok {
-		return s
-	}
-	data, err := json.Marshal(v)
-	if err != nil {
-		return fmt.Sprintf("%v", v)
-	}
-	return string(data)
 }
 
 // statusIn reports whether status is in the list.

--- a/tests/integration/content_format_test.go
+++ b/tests/integration/content_format_test.go
@@ -1,0 +1,434 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/network"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// contentFormatSpec is a minimal OpenAPI spec covering all endpoints used by content format tests.
+const contentFormatSpec = `openapi: "3.0.0"
+info:
+  title: Content Format API
+  version: "1.0"
+paths:
+  /photo:
+    get:
+      operationId: getPhoto
+      summary: Get a photo
+      responses:
+        "200":
+          description: OK
+  /file:
+    get:
+      operationId: getFile
+      summary: Get a file
+      responses:
+        "200":
+          description: OK
+  /orders:
+    post:
+      operationId: createOrder
+      summary: Create an order
+      responses:
+        "201":
+          description: Created
+        "422":
+          description: Unprocessable Entity
+  /broken:
+    get:
+      operationId: getBroken
+      summary: Broken endpoint
+      responses:
+        "500":
+          description: Internal Server Error
+`
+
+// startContentFormatProxy writes spec, optional overlay, and config to a temp dir,
+// then starts the proxy container. Returns the proxy URL.
+func startContentFormatProxy(ctx context.Context, t *testing.T, netName, overlayYAML string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	specPath := filepath.Join(tmpDir, "spec.yaml")
+	if err := os.WriteFile(specPath, []byte(contentFormatSpec), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+
+	cfgContent := `server:
+  port: 8080
+naming:
+  separator: "__"
+telemetry:
+  service_name: mcp-anything
+  service_version: v0.0.0-test
+upstreams:
+  - name: test
+    enabled: true
+    tool_prefix: test
+    base_url: http://wiremock:8080
+    timeout: 10s
+    openapi:
+      source: /etc/mcp-anything/spec.yaml
+      version: "3.0"
+`
+
+	if overlayYAML != "" {
+		cfgContent += `    overlay:
+      source: /etc/mcp-anything/overlay.yaml
+`
+	}
+
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	proxyReq := proxyContainerRequest()
+	proxyReq.ExposedPorts = []string{"8080/tcp"}
+	proxyReq.Networks = []string{netName}
+	proxyReq.Env = map[string]string{
+		"CONFIG_PATH": "/etc/mcp-anything/config.yaml",
+	}
+	proxyReq.Files = []testcontainers.ContainerFile{
+		{HostFilePath: cfgPath, ContainerFilePath: "/etc/mcp-anything/config.yaml", FileMode: 0o644},
+		{HostFilePath: specPath, ContainerFilePath: "/etc/mcp-anything/spec.yaml", FileMode: 0o644},
+	}
+
+	if overlayYAML != "" {
+		overlayPath := filepath.Join(tmpDir, "overlay.yaml")
+		if err := os.WriteFile(overlayPath, []byte(overlayYAML), 0o644); err != nil {
+			t.Fatalf("write overlay: %v", err)
+		}
+		proxyReq.Files = append(proxyReq.Files, testcontainers.ContainerFile{
+			HostFilePath:      overlayPath,
+			ContainerFilePath: "/etc/mcp-anything/overlay.yaml",
+			FileMode:          0o644,
+		})
+	}
+
+	proxyReq.WaitingFor = wait.ForHTTP("/healthz").WithPort("8080").WithStartupTimeout(120 * time.Second)
+	proxy := startContainer(ctx, t, proxyReq)
+
+	proxyHost, err := proxy.Host(ctx)
+	if err != nil {
+		t.Fatalf("get proxy host: %v", err)
+	}
+	proxyPort, err := proxy.MappedPort(ctx, "8080")
+	if err != nil {
+		t.Fatalf("get proxy port: %v", err)
+	}
+	return fmt.Sprintf("http://%s:%s", proxyHost, proxyPort.Port())
+}
+
+// TestImageResponseReturnedAsImageContent verifies that x-mcp-response-format: image
+// causes binary image responses to be returned as ImageContent with correct MIMEType.
+func TestImageResponseReturnedAsImageContent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	net, err := network.New(ctx, network.WithDriver("bridge"))
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := net.Remove(ctx); err != nil {
+			t.Logf("remove network: %v", err)
+		}
+	})
+
+	_, wiremockURL := startWireMock(ctx, t, net.Name)
+
+	// A minimal 1x1 transparent PNG encoded as base64.
+	pngBase64 := "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+	registerStub(t, wiremockURL, fmt.Sprintf(`{
+		"request": {"method": "GET", "url": "/photo"},
+		"response": {
+			"status": 200,
+			"base64Body": %q,
+			"headers": {"Content-Type": "image/png"}
+		}
+	}`, pngBase64))
+
+	overlay := `overlay: 1.0.0
+info:
+  title: Image format overlay
+  version: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+actions:
+  - target: $.paths["/photo"].get
+    update:
+      x-mcp-response-format: image
+`
+
+	proxyURL := startContentFormatProxy(ctx, t, net.Name, overlay)
+	callCtx, callCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer callCancel()
+
+	session := connectMCPClient(callCtx, t, proxyURL)
+
+	result, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{Name: "test__getphoto"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", contentText(result.Content))
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected non-empty content")
+	}
+	ic, ok := result.Content[0].(*sdkmcp.ImageContent)
+	if !ok {
+		t.Fatalf("expected *ImageContent, got %T (text: %s)", result.Content[0], contentText(result.Content))
+	}
+	if ic.MIMEType != "image/png" {
+		t.Errorf("expected MIMEType image/png, got %s", ic.MIMEType)
+	}
+	if len(ic.Data) == 0 {
+		t.Error("expected non-empty image Data")
+	}
+}
+
+// TestAutoDetectBinaryAsBinary verifies that x-mcp-response-format: auto with
+// application/octet-stream Content-Type returns EmbeddedResource content.
+func TestAutoDetectBinaryAsBinary(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	net, err := network.New(ctx, network.WithDriver("bridge"))
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := net.Remove(ctx); err != nil {
+			t.Logf("remove network: %v", err)
+		}
+	})
+
+	_, wiremockURL := startWireMock(ctx, t, net.Name)
+
+	// Some binary data encoded as base64.
+	binaryBase64 := "AQIDBA==" // [0x01, 0x02, 0x03, 0x04]
+	registerStub(t, wiremockURL, fmt.Sprintf(`{
+		"request": {"method": "GET", "url": "/file"},
+		"response": {
+			"status": 200,
+			"base64Body": %q,
+			"headers": {"Content-Type": "application/octet-stream"}
+		}
+	}`, binaryBase64))
+
+	overlay := `overlay: 1.0.0
+info:
+  title: Auto format overlay
+  version: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+actions:
+  - target: $.paths["/file"].get
+    update:
+      x-mcp-response-format: auto
+`
+
+	proxyURL := startContentFormatProxy(ctx, t, net.Name, overlay)
+	callCtx, callCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer callCancel()
+
+	session := connectMCPClient(callCtx, t, proxyURL)
+
+	result, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{Name: "test__getfile"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", contentText(result.Content))
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected non-empty content")
+	}
+	er, ok := result.Content[0].(*sdkmcp.EmbeddedResource)
+	if !ok {
+		t.Fatalf("expected *EmbeddedResource, got %T (text: %s)", result.Content[0], contentText(result.Content))
+	}
+	if er.Resource == nil {
+		t.Fatal("expected non-nil Resource")
+	}
+	if er.Resource.MIMEType != "application/octet-stream" {
+		t.Errorf("expected application/octet-stream, got %s", er.Resource.MIMEType)
+	}
+}
+
+// TestProblemJSONErrorParsed verifies that application/problem+json error bodies
+// are parsed and the default error transform extracts title/detail/status.
+func TestProblemJSONErrorParsed(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	net, err := network.New(ctx, network.WithDriver("bridge"))
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := net.Remove(ctx); err != nil {
+			t.Logf("remove network: %v", err)
+		}
+	})
+
+	_, wiremockURL := startWireMock(ctx, t, net.Name)
+
+	registerStub(t, wiremockURL, `{
+		"request": {"method": "POST", "url": "/orders"},
+		"response": {
+			"status": 422,
+			"jsonBody": {"type": "urn:example:bad-input", "title": "Invalid order", "status": 422, "detail": "quantity must be > 0"},
+			"headers": {"Content-Type": "application/problem+json"}
+		}
+	}`)
+
+	proxyURL := startContentFormatProxy(ctx, t, net.Name, "")
+	callCtx, callCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer callCancel()
+
+	session := connectMCPClient(callCtx, t, proxyURL)
+
+	result, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{Name: "test__createorder"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected IsError=true")
+	}
+	text := contentText(result.Content)
+	if !strings.Contains(text, "Invalid order") {
+		t.Errorf("expected 'Invalid order' in error text, got: %s", text)
+	}
+	if !strings.Contains(text, "quantity must be > 0") {
+		t.Errorf("expected 'quantity must be > 0' in error text, got: %s", text)
+	}
+}
+
+// TestCustomErrorTransform verifies that x-mcp-error-transform is applied to error responses.
+func TestCustomErrorTransform(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	net, err := network.New(ctx, network.WithDriver("bridge"))
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := net.Remove(ctx); err != nil {
+			t.Logf("remove network: %v", err)
+		}
+	})
+
+	_, wiremockURL := startWireMock(ctx, t, net.Name)
+
+	registerStub(t, wiremockURL, `{
+		"request": {"method": "POST", "url": "/orders"},
+		"response": {
+			"status": 422,
+			"jsonBody": {"type": "urn:example:bad-input", "title": "Invalid order", "status": 422, "detail": "quantity must be > 0"},
+			"headers": {"Content-Type": "application/problem+json"}
+		}
+	}`)
+
+	overlay := `overlay: 1.0.0
+info:
+  title: Custom error transform overlay
+  version: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+actions:
+  - target: $.paths["/orders"].post
+    update:
+      x-mcp-error-transform: '{code: .status, message: .title, hint: .detail}'
+`
+
+	proxyURL := startContentFormatProxy(ctx, t, net.Name, overlay)
+	callCtx, callCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer callCancel()
+
+	session := connectMCPClient(callCtx, t, proxyURL)
+
+	result, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{Name: "test__createorder"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected IsError=true")
+	}
+	text := contentText(result.Content)
+	if !strings.Contains(text, "code") {
+		t.Errorf("expected 'code' in error text, got: %s", text)
+	}
+	if !strings.Contains(text, "422") {
+		t.Errorf("expected '422' in error text, got: %s", text)
+	}
+	if !strings.Contains(text, "message") {
+		t.Errorf("expected 'message' in error text, got: %s", text)
+	}
+	if !strings.Contains(text, "Invalid order") {
+		t.Errorf("expected 'Invalid order' in error text, got: %s", text)
+	}
+	if !strings.Contains(text, "hint") {
+		t.Errorf("expected 'hint' in error text, got: %s", text)
+	}
+	if !strings.Contains(text, "quantity must be > 0") {
+		t.Errorf("expected 'quantity must be > 0' in error text, got: %s", text)
+	}
+}
+
+// TestPlainTextErrorResponse verifies that non-JSON error bodies are handled correctly.
+func TestPlainTextErrorResponse(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	net, err := network.New(ctx, network.WithDriver("bridge"))
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := net.Remove(ctx); err != nil {
+			t.Logf("remove network: %v", err)
+		}
+	})
+
+	_, wiremockURL := startWireMock(ctx, t, net.Name)
+
+	registerStub(t, wiremockURL, `{
+		"request": {"method": "GET", "url": "/broken"},
+		"response": {
+			"status": 500,
+			"body": "Internal Server Error",
+			"headers": {"Content-Type": "text/plain"}
+		}
+	}`)
+
+	proxyURL := startContentFormatProxy(ctx, t, net.Name, "")
+	callCtx, callCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer callCancel()
+
+	session := connectMCPClient(callCtx, t, proxyURL)
+
+	result, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{Name: "test__getbroken"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected IsError=true")
+	}
+	text := contentText(result.Content)
+	if !strings.Contains(text, "Internal Server Error") {
+		t.Errorf("expected 'Internal Server Error' in error text, got: %s", text)
+	}
+}


### PR DESCRIPTION
Implements TASK-11: Non-JSON Response Handling and Error Response Transforms

## Changes

- New `internal/content` package with Format detection and MCP content conversion
- `Detect()` auto-detects format from Content-Type (image/*, audio/*, text/*, binary)
- Maps image responses to ImageContent, audio to AudioContent, binary to EmbeddedResource
- Parses application/problem+json bodies per RFC 9457 before error transforms
- Updates DefaultErrorExpr to use (.status // 0) and explicit if-then-else
- Disables HTML escaping in JSON output (SetEscapeHTML(false))
- Wires content package into upstream registry success/error result builders

Closes #14

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and proper handling of various HTTP response content types (JSON, text, images, audio, binary).
  * Improved error response parsing with support for standard error formats.
  * Enhanced response content conversion with optional transformations.

* **Tests**
  * Added comprehensive unit and integration tests for content format detection and response handling across multiple content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->