### PR TITLE
feat: TASK-13 Config Hot-Reload

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -3,23 +3,18 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 
-	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
-
 	"github.com/gaarutyunov/mcp-anything/internal/auth/inbound"
-	"github.com/gaarutyunov/mcp-anything/internal/auth/outbound"
 	"github.com/gaarutyunov/mcp-anything/internal/config"
-	"github.com/gaarutyunov/mcp-anything/internal/openapi"
+	mcppkg "github.com/gaarutyunov/mcp-anything/internal/mcp"
 	"github.com/gaarutyunov/mcp-anything/internal/server"
-	upstreampkg "github.com/gaarutyunov/mcp-anything/internal/upstream"
+	"github.com/gaarutyunov/mcp-anything/internal/telemetry"
 )
 
 func main() {
@@ -31,68 +26,20 @@ func main() {
 		cfgPath = "/etc/mcp-anything/config.yaml"
 	}
 
-	cfg, err := config.Load(cfgPath)
+	// Create the Manager — MCP servers and registry are populated by the first Rebuild.
+	manager := mcppkg.NewManager()
+
+	// NewLoader performs the initial config load and calls manager.Rebuild.
+	// Fatal on initial load or validation failure.
+	loader, err := config.NewLoader(cfgPath, func(cfg *config.ProxyConfig) error {
+		return manager.Rebuild(ctx, cfg)
+	})
 	if err != nil {
-		slog.Error("load config", "error", err)
+		slog.Error("startup failed", "error", err)
 		os.Exit(1)
 	}
 
-	// Validate that no two enabled upstreams share the same tool_prefix (AC-07.5 — fast fail).
-	if err := validateUpstreamPrefixes(cfg.Upstreams); err != nil {
-		slog.Error("invalid upstream configuration", "error", err)
-		os.Exit(1)
-	}
-
-	// Validate each enabled upstream and collect results.
-	var validatedUpstreams []*upstreampkg.ValidatedUpstream
-	for i := range cfg.Upstreams {
-		upCfg := &cfg.Upstreams[i]
-		if !upCfg.Enabled {
-			continue
-		}
-
-		valCtx, valCancel := context.WithTimeout(ctx, upCfg.StartupValidationTimeout)
-		tools, specYAMLRoot, valErr := openapi.ValidateUpstream(valCtx, upCfg, &cfg.Naming)
-		valCancel()
-		if valErr != nil {
-			slog.Error("upstream validation failed", "upstream", upCfg.Name, "error", valErr)
-			os.Exit(1)
-		}
-		slog.Info("validated tools", "upstream", upCfg.Name, "count", len(tools))
-
-		provider, provErr := outbound.NewRegistry().New(ctx, &upCfg.OutboundAuth)
-		if provErr != nil {
-			slog.Error("build outbound auth provider", "upstream", upCfg.Name, "error", provErr)
-			os.Exit(1)
-		}
-
-		validatedUpstreams = append(validatedUpstreams, &upstreampkg.ValidatedUpstream{
-			Config:       upCfg,
-			Tools:        tools,
-			Provider:     provider,
-			SpecYAMLRoot: specYAMLRoot,
-		})
-	}
-
-	// Build groups config — create a default group if none configured.
-	groups := cfg.Groups
-	if len(groups) == 0 {
-		allNames := make([]string, 0, len(validatedUpstreams))
-		for _, vu := range validatedUpstreams {
-			allNames = append(allNames, vu.Config.Name)
-		}
-		groups = []config.GroupConfig{{
-			Name:      "default",
-			Endpoint:  "/mcp",
-			Upstreams: allNames,
-		}}
-	}
-
-	registry, err := upstreampkg.New(validatedUpstreams, &cfg.Naming, groups)
-	if err != nil {
-		slog.Error("build tool registry", "error", err)
-		os.Exit(1)
-	}
+	cfg := loader.Current()
 
 	// Build inbound auth middleware if configured.
 	var authMiddleware func(http.Handler) http.Handler
@@ -127,91 +74,41 @@ func main() {
 
 		selectValidator := func(toolName string) (inbound.TokenValidator, string) {
 			if toolName != "" {
-				upstreamName := registry.ToolUpstreamName(toolName)
+				upstreamName := manager.ToolUpstreamName(toolName)
 				if entry, ok := overrides[upstreamName]; ok {
 					return entry.validator, entry.apiKeyHeader
 				}
 			}
 			return globalValidator, globalHeader
 		}
-		authMiddleware = inbound.MiddlewareWithSelector(selectValidator, registry)
+		// manager implements inbound.RegistryReader via AuthRequired.
+		authMiddleware = inbound.MiddlewareWithSelector(selectValidator, manager)
 	}
 
-	// Build one MCP handler per group, each mounted at the group's endpoint.
-	mcpHandlers := make(map[string]http.Handler, len(groups))
-	for _, g := range groups {
-		groupName := g.Name
-		groupToolList := registry.ToolsForGroup(groupName)
-
-		groupSrv := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "mcp-anything", Version: cfg.Telemetry.ServiceVersion}, nil)
-		for _, tool := range groupToolList {
-			t := tool // capture for closure
-			groupSrv.AddTool(t, func(callCtx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
-				args, parseErr := parseArguments(req.Params.Arguments)
-				if parseErr != nil {
-					return nil, fmt.Errorf("parsing tool arguments: %w", parseErr)
-				}
-				return registry.DispatchForGroup(callCtx, groupName, req.Params.Name, args)
-			})
-		}
-
-		var groupHandler http.Handler = sdkmcp.NewStreamableHTTPHandler(func(_ *http.Request) *sdkmcp.Server { return groupSrv }, nil)
+	// Wrap MCP handlers with auth middleware if configured.
+	rawHandlers := manager.HTTPHandlers()
+	mcpHandlers := make(map[string]http.Handler, len(rawHandlers))
+	for endpoint, handler := range rawHandlers {
+		h := handler
 		if authMiddleware != nil {
-			groupHandler = authMiddleware(groupHandler)
+			h = authMiddleware(h)
 		}
-		mcpHandlers[g.Endpoint] = groupHandler
-		slog.Info("mounted group", "name", groupName, "endpoint", g.Endpoint, "tools", len(groupToolList))
+		mcpHandlers[endpoint] = h
+		slog.Info("mounted group", "endpoint", endpoint)
 	}
 
 	var wellKnown http.HandlerFunc
 	if cfg.InboundAuth.Strategy == "jwt" || cfg.InboundAuth.Strategy == "introspection" {
 		wellKnown = inbound.WellKnownHandler(cfg)
 	}
-	srv := server.New(cfg, mcpHandlers, wellKnown)
+
+	srv := server.New(cfg, mcpHandlers, wellKnown, telemetry.ReloadMetricsHandler())
+
+	// Start config watcher in background.
+	go loader.Watch(ctx)
 
 	if err := srv.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		slog.Error("server", "error", err)
 		os.Exit(1)
 	}
-}
-
-// validateUpstreamPrefixes returns an error if any two enabled upstreams share the same tool_prefix.
-func validateUpstreamPrefixes(upstreams []config.UpstreamConfig) error {
-	seen := make(map[string]string) // prefix → upstream name
-	for _, up := range upstreams {
-		if !up.Enabled {
-			continue
-		}
-		if prev, ok := seen[up.ToolPrefix]; ok {
-			return fmt.Errorf("upstreams %q and %q share the same tool_prefix %q", prev, up.Name, up.ToolPrefix)
-		}
-		seen[up.ToolPrefix] = up.Name
-	}
-	return nil
-}
-
-// parseArguments unmarshals the tool call arguments into a map.
-func parseArguments(raw any) (map[string]any, error) {
-	if raw == nil {
-		return make(map[string]any), nil
-	}
-
-	b, ok := raw.(json.RawMessage)
-	if !ok {
-		data, err := json.Marshal(raw)
-		if err != nil {
-			return nil, fmt.Errorf("re-marshalling arguments: %w", err)
-		}
-		b = data
-	}
-
-	if len(b) == 0 || string(b) == "null" {
-		return make(map[string]any), nil
-	}
-
-	var args map[string]any
-	if err := json.Unmarshal(b, &args); err != nil {
-		return nil, fmt.Errorf("unmarshalling arguments: %w", err)
-	}
-	return args, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/brianvoe/gofakeit/v6 v6.28.0
 	github.com/coreos/go-oidc/v3 v3.17.0
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/getkin/kin-openapi v0.134.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/google/jsonschema-go v0.4.2
@@ -39,7 +40,6 @@ require (
 	github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960 // indirect
 	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1,13 +1,122 @@
 package config
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
+	"path/filepath"
+	"sync/atomic"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
+
+	"github.com/gaarutyunov/mcp-anything/internal/telemetry"
 )
+
+// Loader watches a config file and atomically updates the live configuration on change.
+type Loader struct {
+	path    string
+	current atomic.Pointer[ProxyConfig]
+	onLoad  func(*ProxyConfig) error
+}
+
+// NewLoader creates a Loader, performs the initial load and validation, and returns.
+// If the initial load or validation fails, it returns an error (callers should treat this as fatal).
+func NewLoader(path string, onLoad func(*ProxyConfig) error) (*Loader, error) {
+	l := &Loader{
+		path:   path,
+		onLoad: onLoad,
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		return nil, fmt.Errorf("initial config load: %w", err)
+	}
+	if err := onLoad(cfg); err != nil {
+		return nil, fmt.Errorf("initial validation: %w", err)
+	}
+	l.current.Store(cfg)
+	return l, nil
+}
+
+// Current returns the currently active configuration. Safe for concurrent reads.
+func (l *Loader) Current() *ProxyConfig {
+	return l.current.Load()
+}
+
+// Watch starts the fsnotify watcher for the parent directory of the config file.
+// It debounces CREATE events (500 ms) before triggering a reload.
+// Blocks until ctx is cancelled.
+func (l *Loader) Watch(ctx context.Context) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		slog.Error("creating config watcher", "error", err)
+		return
+	}
+	defer func() {
+		if closeErr := watcher.Close(); closeErr != nil {
+			slog.Warn("closing config watcher", "error", closeErr)
+		}
+	}()
+
+	dir := filepath.Dir(l.path)
+	if err := watcher.Add(dir); err != nil {
+		slog.Error("watching config directory", "path", dir, "error", err)
+		return
+	}
+	slog.Info("config watcher started", "path", l.path)
+
+	var debounceTimer *time.Timer
+	for {
+		select {
+		case <-ctx.Done():
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			return
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			if event.Op&(fsnotify.Create|fsnotify.Write) == 0 {
+				continue
+			}
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.AfterFunc(500*time.Millisecond, func() {
+				l.tryReload(ctx)
+			})
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			slog.Error("config watcher error", "error", err)
+		}
+	}
+}
+
+// tryReload attempts to load and validate the config file. On success it atomically swaps
+// the active config. On failure it retains the previous config and logs the error.
+func (l *Loader) tryReload(ctx context.Context) {
+	telemetry.IncrConfigReloadTotal()
+
+	cfg, err := Load(l.path)
+	if err != nil {
+		slog.Error("config reload failed", "error", err)
+		telemetry.IncrConfigReloadErrors()
+		return
+	}
+	if err := l.onLoad(cfg); err != nil {
+		slog.Error("config reload failed", "error", err)
+		telemetry.IncrConfigReloadErrors()
+		return
+	}
+	l.current.Store(cfg)
+	slog.Info("config reloaded", "upstreams", len(cfg.Upstreams))
+}
 
 // Load reads the YAML config file at path and returns a ProxyConfig with
 // defaults applied for any missing fields.

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -1,0 +1,255 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/gaarutyunov/mcp-anything/internal/auth/outbound"
+	"github.com/gaarutyunov/mcp-anything/internal/config"
+	"github.com/gaarutyunov/mcp-anything/internal/openapi"
+	upstreampkg "github.com/gaarutyunov/mcp-anything/internal/upstream"
+)
+
+// Manager owns the MCP servers and live tool registry.
+// It rebuilds and updates them on config reload.
+type Manager struct {
+	servers  map[string]*sdkmcp.Server // keyed by group endpoint
+	registry *upstreampkg.Registry
+	impl     *sdkmcp.Implementation // set on first Rebuild
+	mu       sync.RWMutex
+}
+
+// NewManager creates a Manager with no active servers.
+func NewManager() *Manager {
+	return &Manager{
+		servers: make(map[string]*sdkmcp.Server),
+	}
+}
+
+// HTTPHandlers returns HTTP handlers for each group endpoint.
+// Must be called after the initial Rebuild so servers are populated.
+func (m *Manager) HTTPHandlers() map[string]http.Handler {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	handlers := make(map[string]http.Handler, len(m.servers))
+	for endpoint, srv := range m.servers {
+		s := srv // capture for closure
+		handlers[endpoint] = sdkmcp.NewStreamableHTTPHandler(func(_ *http.Request) *sdkmcp.Server { return s }, nil)
+	}
+	return handlers
+}
+
+// AuthRequired implements inbound.RegistryReader. Returns true (conservative
+// default) when no registry is loaded or the tool is unknown.
+func (m *Manager) AuthRequired(toolName string) bool {
+	m.mu.RLock()
+	reg := m.registry
+	m.mu.RUnlock()
+	if reg == nil {
+		return true
+	}
+	return reg.AuthRequired(toolName)
+}
+
+// ToolUpstreamName returns the upstream name for the given tool, or an empty
+// string if unknown. Used by inbound auth middleware to select per-upstream validators.
+func (m *Manager) ToolUpstreamName(toolName string) string {
+	m.mu.RLock()
+	reg := m.registry
+	m.mu.RUnlock()
+	if reg == nil {
+		return ""
+	}
+	return reg.ToolUpstreamName(toolName)
+}
+
+// DispatchForGroup dispatches a tool call for the named group using the current registry.
+func (m *Manager) DispatchForGroup(ctx context.Context, groupName, toolName string, args map[string]any) (*sdkmcp.CallToolResult, error) {
+	m.mu.RLock()
+	reg := m.registry
+	m.mu.RUnlock()
+	if reg == nil {
+		return &sdkmcp.CallToolResult{
+			IsError: true,
+			Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "no config loaded"}},
+		}, nil
+	}
+	return reg.DispatchForGroup(ctx, groupName, toolName, args)
+}
+
+// Rebuild revalidates all upstreams from the new config, builds a new registry,
+// and diffs the tool sets to call AddTool/RemoveTools on each MCP server.
+// Connected clients receive notifications/tools/list_changed automatically.
+// If any upstream validation fails, the existing registry and servers are unchanged.
+func (m *Manager) Rebuild(ctx context.Context, cfg *config.ProxyConfig) error {
+	// Set Implementation on first Rebuild.
+	if m.impl == nil {
+		m.impl = &sdkmcp.Implementation{
+			Name:    "mcp-anything",
+			Version: cfg.Telemetry.ServiceVersion,
+		}
+	}
+
+	// Validate that no two enabled upstreams share the same tool_prefix.
+	if err := validateUpstreamPrefixes(cfg.Upstreams); err != nil {
+		return fmt.Errorf("invalid upstream configuration: %w", err)
+	}
+
+	// Validate each enabled upstream with its configured timeout.
+	var validatedUpstreams []*upstreampkg.ValidatedUpstream
+	for i := range cfg.Upstreams {
+		upCfg := &cfg.Upstreams[i]
+		if !upCfg.Enabled {
+			continue
+		}
+
+		valCtx, valCancel := context.WithTimeout(ctx, upCfg.StartupValidationTimeout)
+		tools, specYAMLRoot, valErr := openapi.ValidateUpstream(valCtx, upCfg, &cfg.Naming)
+		valCancel()
+		if valErr != nil {
+			return fmt.Errorf("upstream %q validation failed: %w", upCfg.Name, valErr)
+		}
+		slog.Info("validated tools", "upstream", upCfg.Name, "count", len(tools))
+
+		provider, provErr := outbound.NewRegistry().New(ctx, &upCfg.OutboundAuth)
+		if provErr != nil {
+			return fmt.Errorf("build outbound auth for upstream %q: %w", upCfg.Name, provErr)
+		}
+
+		validatedUpstreams = append(validatedUpstreams, &upstreampkg.ValidatedUpstream{
+			Config:       upCfg,
+			Tools:        tools,
+			Provider:     provider,
+			SpecYAMLRoot: specYAMLRoot,
+		})
+	}
+
+	// Build group config — synthesise a default group if none are configured.
+	groups := cfg.Groups
+	if len(groups) == 0 {
+		allNames := make([]string, 0, len(validatedUpstreams))
+		for _, vu := range validatedUpstreams {
+			allNames = append(allNames, vu.Config.Name)
+		}
+		groups = []config.GroupConfig{{
+			Name:      "default",
+			Endpoint:  "/mcp",
+			Upstreams: allNames,
+		}}
+	}
+
+	// Build new registry (full validation; no partial updates on error).
+	newRegistry, err := upstreampkg.New(validatedUpstreams, &cfg.Naming, groups)
+	if err != nil {
+		return fmt.Errorf("building tool registry: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, g := range groups {
+		groupName := g.Name // capture for closure
+
+		srv, exists := m.servers[g.Endpoint]
+		if !exists {
+			srv = sdkmcp.NewServer(m.impl, nil)
+			m.servers[g.Endpoint] = srv
+		}
+
+		newTools := newRegistry.ToolsForGroup(g.Name)
+
+		// Build set of new tool names for O(1) lookups.
+		newToolSet := make(map[string]bool, len(newTools))
+		for _, t := range newTools {
+			newToolSet[t.Name] = true
+		}
+
+		// Build set of existing tool names for diffing.
+		oldToolSet := make(map[string]bool)
+		if m.registry != nil {
+			for _, t := range m.registry.ToolsForGroup(g.Name) {
+				oldToolSet[t.Name] = true
+			}
+		}
+
+		// Remove tools no longer present in the new registry.
+		var removedNames []string
+		for name := range oldToolSet {
+			if !newToolSet[name] {
+				removedNames = append(removedNames, name)
+			}
+		}
+		if len(removedNames) > 0 {
+			srv.RemoveTools(removedNames...)
+		}
+
+		// Add or replace tools (AddTool replaces existing tools with the same name).
+		var addedNames []string
+		for _, tool := range newTools {
+			if !oldToolSet[tool.Name] {
+				addedNames = append(addedNames, tool.Name)
+			}
+			t := tool       // capture
+			gn := groupName // capture
+			srv.AddTool(t, func(callCtx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+				args, parseErr := managerParseArguments(req.Params.Arguments)
+				if parseErr != nil {
+					return nil, fmt.Errorf("parsing tool arguments: %w", parseErr)
+				}
+				return m.DispatchForGroup(callCtx, gn, req.Params.Name, args)
+			})
+		}
+
+		if len(addedNames) > 0 || len(removedNames) > 0 {
+			slog.Info("config reloaded tools", "group", g.Name, "added", addedNames, "removed", removedNames)
+		}
+	}
+
+	m.registry = newRegistry
+	return nil
+}
+
+// validateUpstreamPrefixes returns an error if any two enabled upstreams share the same tool_prefix.
+func validateUpstreamPrefixes(upstreams []config.UpstreamConfig) error {
+	seen := make(map[string]string)
+	for _, up := range upstreams {
+		if !up.Enabled {
+			continue
+		}
+		if prev, ok := seen[up.ToolPrefix]; ok {
+			return fmt.Errorf("upstreams %q and %q share the same tool_prefix %q", prev, up.Name, up.ToolPrefix)
+		}
+		seen[up.ToolPrefix] = up.Name
+	}
+	return nil
+}
+
+// managerParseArguments unmarshals tool call arguments into a map.
+func managerParseArguments(raw any) (map[string]any, error) {
+	if raw == nil {
+		return make(map[string]any), nil
+	}
+	b, ok := raw.(json.RawMessage)
+	if !ok {
+		data, err := json.Marshal(raw)
+		if err != nil {
+			return nil, fmt.Errorf("re-marshalling arguments: %w", err)
+		}
+		b = data
+	}
+	if len(b) == 0 || string(b) == "null" {
+		return make(map[string]any), nil
+	}
+	var args map[string]any
+	if err := json.Unmarshal(b, &args); err != nil {
+		return nil, fmt.Errorf("unmarshalling arguments: %w", err)
+	}
+	return args, nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,7 +23,8 @@ type Server struct {
 // New creates a new Server. mcpHandlers maps mount paths to their HTTP handlers.
 // wellKnown is an optional handler for the OAuth 2.0 Protected Resource Metadata endpoint
 // (GET /.well-known/oauth-protected-resource); pass nil to skip mounting it.
-func New(cfg *config.ProxyConfig, mcpHandlers map[string]http.Handler, wellKnown http.HandlerFunc) *Server {
+// reloadMetrics is an optional handler for the GET /metrics/reload endpoint; pass nil to skip.
+func New(cfg *config.ProxyConfig, mcpHandlers map[string]http.Handler, wellKnown http.HandlerFunc, reloadMetrics http.HandlerFunc) *Server {
 	r := chi.NewRouter()
 
 	// Health endpoints.
@@ -33,6 +34,11 @@ func New(cfg *config.ProxyConfig, mcpHandlers map[string]http.Handler, wellKnown
 	r.Get("/readyz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+
+	// Reload metrics endpoint.
+	if reloadMetrics != nil {
+		r.Get("/metrics/reload", reloadMetrics)
+	}
 
 	// Well-known OAuth metadata endpoint (always public, mounted before auth middleware).
 	if wellKnown != nil {

--- a/internal/telemetry/reload.go
+++ b/internal/telemetry/reload.go
@@ -1,0 +1,33 @@
+package telemetry
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+)
+
+var (
+	configReloadTotal  atomic.Int64
+	configReloadErrors atomic.Int64
+)
+
+// IncrConfigReloadTotal increments the total reload attempt counter.
+func IncrConfigReloadTotal() { configReloadTotal.Add(1) }
+
+// IncrConfigReloadErrors increments the reload error counter.
+func IncrConfigReloadErrors() { configReloadErrors.Add(1) }
+
+// ReloadTotal returns the total number of reload attempts.
+func ReloadTotal() int64 { return configReloadTotal.Load() }
+
+// ReloadErrors returns the number of failed reload attempts.
+func ReloadErrors() int64 { return configReloadErrors.Load() }
+
+// ReloadMetricsHandler returns an HTTP handler that exposes reload counters as plain text.
+func ReloadMetricsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = fmt.Fprintf(w, "mcp_anything_config_reload_total %d\nmcp_anything_config_reload_errors_total %d\n",
+			configReloadTotal.Load(), configReloadErrors.Load())
+	}
+}

--- a/tests/integration/config_reload_test.go
+++ b/tests/integration/config_reload_test.go
@@ -1,0 +1,505 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/network"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// petsOnlySpec has a single GET /pets operation.
+const petsOnlySpec = `openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0"
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List all pets
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+`
+
+// petsAndOrdersSpec has GET /pets and GET /orders.
+const petsAndOrdersSpec = `openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0"
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List all pets
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+  /orders:
+    get:
+      operationId: listOrders
+      summary: List all orders
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+`
+
+// twoToolsSpec has GET /pets and GET /cats (both operations present from the start).
+const twoToolsSpec = `openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0"
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List all pets
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+  /cats:
+    get:
+      operationId: listCats
+      summary: List all cats
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+`
+
+// reloadConfig returns a config YAML string that uses the given spec filename.
+func reloadConfig(specFile string) string {
+	return fmt.Sprintf(`server:
+  port: 8080
+naming:
+  separator: "__"
+telemetry:
+  service_name: mcp-anything
+  service_version: v0.0.0-test
+upstreams:
+  - name: pets
+    enabled: true
+    tool_prefix: pets
+    base_url: http://wiremock:8080
+    timeout: 10s
+    openapi:
+      source: /etc/mcp-anything/%s
+      version: "3.0"
+`, specFile)
+}
+
+// copyToContainer writes content to a file inside the running container.
+// This triggers an inotify event in the container's filesystem.
+func copyToContainer(ctx context.Context, t *testing.T, c testcontainers.Container, containerPath string, content []byte) {
+	t.Helper()
+	if err := c.CopyToContainer(ctx, content, containerPath, 0o644); err != nil {
+		t.Fatalf("copy to container %s: %v", containerPath, err)
+	}
+}
+
+// startReloadProxy writes initial config files to a temp dir, copies them into the proxy
+// container at startup, and returns the proxy container and its base URL.
+func startReloadProxy(ctx context.Context, t *testing.T, net *testcontainers.DockerNetwork, initialSpec, initialConfig string) (testcontainers.Container, string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	specPath := filepath.Join(tmpDir, "spec.yaml")
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(specPath, []byte(initialSpec), 0o644); err != nil {
+		t.Fatalf("write spec file: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(initialConfig), 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	proxyReq := proxyContainerRequest()
+	proxyReq.ExposedPorts = []string{"8080/tcp"}
+	proxyReq.Networks = []string{net.Name}
+	proxyReq.Env = map[string]string{
+		"CONFIG_PATH": "/etc/mcp-anything/config.yaml",
+	}
+	proxyReq.Files = []testcontainers.ContainerFile{
+		{HostFilePath: cfgPath, ContainerFilePath: "/etc/mcp-anything/config.yaml", FileMode: 0o644},
+		{HostFilePath: specPath, ContainerFilePath: "/etc/mcp-anything/spec.yaml", FileMode: 0o644},
+	}
+	proxyReq.WaitingFor = wait.ForHTTP("/healthz").WithPort("8080").WithStartupTimeout(120 * time.Second)
+
+	proxy := startContainer(ctx, t, proxyReq)
+
+	proxyHost, err := proxy.Host(ctx)
+	if err != nil {
+		t.Fatalf("get proxy host: %v", err)
+	}
+	proxyPort, err := proxy.MappedPort(ctx, "8080")
+	if err != nil {
+		t.Fatalf("get proxy port: %v", err)
+	}
+	return proxy, fmt.Sprintf("http://%s:%s", proxyHost, proxyPort.Port())
+}
+
+// pollToolsUntil polls tools/list every 100 ms (up to timeout) until predicate returns true.
+func pollToolsUntil(t *testing.T, session *sdkmcp.ClientSession, callCtx context.Context, predicate func([]*sdkmcp.Tool) bool, timeout time.Duration) []*sdkmcp.Tool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		result, err := session.ListTools(callCtx, nil)
+		if err == nil && predicate(result.Tools) {
+			return result.Tools
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	result, err := session.ListTools(callCtx, nil)
+	if err != nil {
+		t.Fatalf("list tools after poll timeout: %v", err)
+	}
+	return result.Tools
+}
+
+// readReloadMetrics fetches the /metrics/reload endpoint and returns the body.
+func readReloadMetrics(t *testing.T, proxyURL string) string {
+	t.Helper()
+	resp, err := http.Get(proxyURL + "/metrics/reload") //nolint:noctx // test helper
+	if err != nil {
+		t.Fatalf("GET /metrics/reload: %v", err)
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read /metrics/reload body: %v", err)
+	}
+	return string(b)
+}
+
+// startWiremock starts a WireMock container and returns its external URL.
+func startWiremock(ctx context.Context, t *testing.T, net *testcontainers.DockerNetwork) string {
+	t.Helper()
+	wm := startContainer(ctx, t, testcontainers.ContainerRequest{
+		Image:        "wiremock/wiremock:3.9.1",
+		ExposedPorts: []string{"8080/tcp"},
+		Networks:     []string{net.Name},
+		NetworkAliases: map[string][]string{
+			net.Name: {"wiremock"},
+		},
+		WaitingFor: wait.ForHTTP("/__admin/mappings").WithPort("8080").WithStartupTimeout(60 * time.Second),
+	})
+	wmHost, err := wm.Host(ctx)
+	if err != nil {
+		t.Fatalf("get wiremock host: %v", err)
+	}
+	wmPort, err := wm.MappedPort(ctx, "8080")
+	if err != nil {
+		t.Fatalf("get wiremock port: %v", err)
+	}
+	return fmt.Sprintf("http://%s:%s", wmHost, wmPort.Port())
+}
+
+// TestConfigHotReloadAddsNewTool verifies that adding a new operation to the spec
+// causes the proxy to expose an additional MCP tool without restart.
+func TestConfigHotReloadAddsNewTool(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	net, err := network.New(ctx, network.WithDriver("bridge"))
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := net.Remove(ctx); err != nil {
+			t.Logf("remove network: %v", err)
+		}
+	})
+
+	wiremockURL := startWiremock(ctx, t, net)
+	registerStub(t, wiremockURL, `{"request":{"method":"GET","url":"/pets"},"response":{"status":200,"body":"{}","headers":{"Content-Type":"application/json"}}}`)
+	registerStub(t, wiremockURL, `{"request":{"method":"GET","url":"/orders"},"response":{"status":200,"body":"{}","headers":{"Content-Type":"application/json"}}}`)
+
+	proxy, proxyURL := startReloadProxy(ctx, t, net, petsOnlySpec, reloadConfig("spec.yaml"))
+
+	transport := &sdkmcp.StreamableClientTransport{Endpoint: proxyURL + "/mcp"}
+	mcpClient := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	callCtx, callCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer callCancel()
+
+	session, err := mcpClient.Connect(callCtx, transport, nil)
+	if err != nil {
+		t.Fatalf("connect MCP client: %v", err)
+	}
+	defer session.Close()
+
+	// Assert initial tool list has 1 tool.
+	initialTools, err := session.ListTools(callCtx, nil)
+	if err != nil {
+		t.Fatalf("list tools (initial): %v", err)
+	}
+	if len(initialTools.Tools) != 1 {
+		t.Fatalf("expected 1 initial tool, got %d: %v", len(initialTools.Tools), toolNames(initialTools.Tools))
+	}
+	if initialTools.Tools[0].Name != "pets__listpets" {
+		t.Errorf("expected tool pets__listpets, got %s", initialTools.Tools[0].Name)
+	}
+
+	// Trigger reload: copy updated spec with new operation, then update config.
+	copyToContainer(ctx, t, proxy, "/etc/mcp-anything/spec_v2.yaml", []byte(petsAndOrdersSpec))
+	copyToContainer(ctx, t, proxy, "/etc/mcp-anything/config.yaml", []byte(reloadConfig("spec_v2.yaml")))
+
+	// Poll until 2 tools appear (up to 5 seconds).
+	reloadedTools := pollToolsUntil(t, session, callCtx, func(tools []*sdkmcp.Tool) bool {
+		return len(tools) == 2
+	}, 5*time.Second)
+
+	if len(reloadedTools) != 2 {
+		t.Fatalf("expected 2 tools after reload, got %d: %v", len(reloadedTools), toolNames(reloadedTools))
+	}
+	nameSet := make(map[string]bool, len(reloadedTools))
+	for _, tool := range reloadedTools {
+		nameSet[tool.Name] = true
+	}
+	if !nameSet["pets__listpets"] {
+		t.Errorf("missing tool pets__listpets after reload; got: %v", toolNames(reloadedTools))
+	}
+	if !nameSet["pets__listorders"] {
+		t.Errorf("missing tool pets__listorders after reload; got: %v", toolNames(reloadedTools))
+	}
+}
+
+// TestConfigHotReloadRemovesTool verifies that removing an operation from the spec
+// causes the proxy to remove the corresponding MCP tool without restart.
+func TestConfigHotReloadRemovesTool(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	net, err := network.New(ctx, network.WithDriver("bridge"))
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := net.Remove(ctx); err != nil {
+			t.Logf("remove network: %v", err)
+		}
+	})
+
+	wiremockURL := startWiremock(ctx, t, net)
+	registerStub(t, wiremockURL, `{"request":{"method":"GET","url":"/pets"},"response":{"status":200,"body":"{}","headers":{"Content-Type":"application/json"}}}`)
+
+	proxy, proxyURL := startReloadProxy(ctx, t, net, twoToolsSpec, reloadConfig("spec.yaml"))
+
+	transport := &sdkmcp.StreamableClientTransport{Endpoint: proxyURL + "/mcp"}
+	mcpClient := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	callCtx, callCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer callCancel()
+
+	session, err := mcpClient.Connect(callCtx, transport, nil)
+	if err != nil {
+		t.Fatalf("connect MCP client: %v", err)
+	}
+	defer session.Close()
+
+	// Assert initial tool list has 2 tools.
+	initialTools, err := session.ListTools(callCtx, nil)
+	if err != nil {
+		t.Fatalf("list tools (initial): %v", err)
+	}
+	if len(initialTools.Tools) != 2 {
+		t.Fatalf("expected 2 initial tools, got %d: %v", len(initialTools.Tools), toolNames(initialTools.Tools))
+	}
+
+	// Reload with spec that has only 1 tool.
+	copyToContainer(ctx, t, proxy, "/etc/mcp-anything/spec_v2.yaml", []byte(petsOnlySpec))
+	copyToContainer(ctx, t, proxy, "/etc/mcp-anything/config.yaml", []byte(reloadConfig("spec_v2.yaml")))
+
+	// Poll until 1 tool remains (up to 5 seconds).
+	reloadedTools := pollToolsUntil(t, session, callCtx, func(tools []*sdkmcp.Tool) bool {
+		return len(tools) == 1
+	}, 5*time.Second)
+
+	if len(reloadedTools) != 1 {
+		t.Fatalf("expected 1 tool after reload, got %d: %v", len(reloadedTools), toolNames(reloadedTools))
+	}
+	if reloadedTools[0].Name != "pets__listpets" {
+		t.Errorf("expected pets__listpets to remain, got %s", reloadedTools[0].Name)
+	}
+}
+
+// TestInvalidConfigReloadKeepsOldConfig verifies that writing invalid YAML does not
+// replace the active config: the old tools remain available and /readyz stays 200.
+func TestInvalidConfigReloadKeepsOldConfig(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	net, err := network.New(ctx, network.WithDriver("bridge"))
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := net.Remove(ctx); err != nil {
+			t.Logf("remove network: %v", err)
+		}
+	})
+
+	wiremockURL := startWiremock(ctx, t, net)
+	registerStub(t, wiremockURL, `{"request":{"method":"GET","url":"/pets"},"response":{"status":200,"body":"{}","headers":{"Content-Type":"application/json"}}}`)
+
+	proxy, proxyURL := startReloadProxy(ctx, t, net, petsOnlySpec, reloadConfig("spec.yaml"))
+
+	transport := &sdkmcp.StreamableClientTransport{Endpoint: proxyURL + "/mcp"}
+	mcpClient := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	callCtx, callCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer callCancel()
+
+	session, err := mcpClient.Connect(callCtx, transport, nil)
+	if err != nil {
+		t.Fatalf("connect MCP client: %v", err)
+	}
+	defer session.Close()
+
+	// Verify initial state.
+	initialTools, err := session.ListTools(callCtx, nil)
+	if err != nil {
+		t.Fatalf("list tools (initial): %v", err)
+	}
+	if len(initialTools.Tools) != 1 {
+		t.Fatalf("expected 1 initial tool, got %d: %v", len(initialTools.Tools), toolNames(initialTools.Tools))
+	}
+
+	// Trigger a failed reload: valid YAML but references a nonexistent spec file so
+	// manager.Rebuild fails during upstream validation.
+	invalidConfig := `server:
+  port: 8080
+naming:
+  separator: "__"
+telemetry:
+  service_name: mcp-anything
+  service_version: v0.0.0-test
+upstreams:
+  - name: pets
+    enabled: true
+    tool_prefix: pets
+    base_url: http://wiremock:8080
+    timeout: 10s
+    openapi:
+      source: /etc/mcp-anything/nonexistent.yaml
+      version: "3.0"
+`
+	copyToContainer(ctx, t, proxy, "/etc/mcp-anything/config.yaml", []byte(invalidConfig))
+
+	// Wait for the reload attempt to settle (debounce 500ms + processing time).
+	time.Sleep(2 * time.Second)
+
+	// Old tools still present.
+	afterTools, err := session.ListTools(callCtx, nil)
+	if err != nil {
+		t.Fatalf("list tools after failed reload: %v", err)
+	}
+	if len(afterTools.Tools) != 1 {
+		t.Fatalf("expected 1 tool after failed reload, got %d: %v", len(afterTools.Tools), toolNames(afterTools.Tools))
+	}
+	if afterTools.Tools[0].Name != "pets__listpets" {
+		t.Errorf("expected pets__listpets to remain, got %s", afterTools.Tools[0].Name)
+	}
+
+	// /readyz must return 200 (AC-30.4).
+	assertHTTPStatus(t, proxyURL+"/readyz", http.StatusOK)
+
+	// Reload error counter must be > 0.
+	metrics := readReloadMetrics(t, proxyURL)
+	if metrics == "" {
+		t.Fatal("empty /metrics/reload response")
+	}
+	var totalCount, errorCount int
+	if _, scanErr := fmt.Sscanf(metrics, "mcp_anything_config_reload_total %d\nmcp_anything_config_reload_errors_total %d", &totalCount, &errorCount); scanErr != nil {
+		t.Fatalf("parsing reload metrics %q: %v", metrics, scanErr)
+	}
+	if errorCount == 0 {
+		t.Errorf("expected reload error counter > 0 after failed reload, got 0; metrics: %s", metrics)
+	}
+}
+
+// TestReloadRespectsDebounce verifies that writing multiple config files in rapid
+// succession results in only a single reload, thanks to the 500 ms debounce.
+func TestReloadRespectsDebounce(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	net, err := network.New(ctx, network.WithDriver("bridge"))
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := net.Remove(ctx); err != nil {
+			t.Logf("remove network: %v", err)
+		}
+	})
+
+	wiremockURL := startWiremock(ctx, t, net)
+	registerStub(t, wiremockURL, `{"request":{"method":"GET","url":"/pets"},"response":{"status":200,"body":"{}","headers":{"Content-Type":"application/json"}}}`)
+
+	proxy, proxyURL := startReloadProxy(ctx, t, net, petsOnlySpec, reloadConfig("spec.yaml"))
+
+	// Read baseline reload total before triggering.
+	baseMetrics := readReloadMetrics(t, proxyURL)
+	var baseTotal int
+	fmt.Sscanf(baseMetrics, "mcp_anything_config_reload_total %d", &baseTotal) //nolint:errcheck // best-effort parse
+
+	// Write 5 config files in rapid succession (simulating ConfigMap churn).
+	// Each write triggers a fsnotify event; debounce should collapse them into one reload.
+	for i := 0; i < 5; i++ {
+		copyToContainer(ctx, t, proxy, "/etc/mcp-anything/config.yaml", []byte(reloadConfig("spec.yaml")))
+		time.Sleep(50 * time.Millisecond) // well within the 500 ms debounce window
+	}
+
+	// Wait for the single debounced reload to complete (debounce 500ms + processing).
+	time.Sleep(3 * time.Second)
+
+	afterMetrics := readReloadMetrics(t, proxyURL)
+	var afterTotal int
+	fmt.Sscanf(afterMetrics, "mcp_anything_config_reload_total %d", &afterTotal) //nolint:errcheck // best-effort parse
+
+	reloads := afterTotal - baseTotal
+	if reloads == 0 {
+		t.Errorf("expected at least 1 reload, got 0; metrics: %s", afterMetrics)
+	}
+	// Allow up to 3 reloads (debounce is best-effort; exact count may vary by platform and container I/O speed).
+	if reloads > 3 {
+		t.Errorf("expected at most 3 reloads for 5 rapid writes (debounce), got %d; metrics: %s", reloads, afterMetrics)
+	}
+}


### PR DESCRIPTION
Implements config hot-reload without process restart as described in issue #16.

## Changes

- `internal/config/loader.go`: Add `Loader` struct with fsnotify watcher (500ms debounce, CREATE+WRITE events) and atomic config swap
- `internal/mcp/manager.go`: New `Manager` that rebuilds the tool registry and diffs `AddTool`/`RemoveTools` on live MCP servers
- `internal/telemetry/reload.go`: Atomic reload counters exposed at `GET /metrics/reload`
- `internal/server/server.go`: Mount `/metrics/reload` endpoint
- `cmd/proxy/main.go`: Wire Manager + NewLoader + background Watch
- `tests/integration/config_reload_test.go`: Four integration tests

Closes #16

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live configuration reloading without service restart
  * New `/metrics/reload` endpoint to track configuration reload attempts and errors
  * Invalid configurations are safely rejected while preserving the previous working configuration

* **Tests**
  * Added integration tests validating hot-reload scenarios, including tool addition/removal and error handling

* **Chores**
  * Updated dependencies for file-watching capability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->