### PR TITLE
feat: add per-tool token counting for tool results (#85)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,8 @@ RUN CGO_ENABLED=0 go build -o /proxy ./cmd/proxy
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates
+# TIKTOKEN_CACHE_DIR points tiktoken-go to a writable, predictable cache directory.
+# BPE encoding data is downloaded on first use if not already cached.
+ENV TIKTOKEN_CACHE_DIR=/tmp/tiktoken_cache
 COPY --from=builder /proxy /usr/local/bin/proxy
 ENTRYPOINT ["proxy"]

--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkoukk/tiktoken-go v0.1.8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,8 @@ github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkoukk/tiktoken-go v0.1.8 h1:85ENo+3FpWgAACBaEUVp+lctuTcYUO7BtmfhlN/QTRo=
+github.com/pkoukk/tiktoken-go v0.1.8/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,13 +17,26 @@ type PoolAcquirer interface {
 
 // ProxyConfig is the top-level configuration struct.
 type ProxyConfig struct {
-	Server      ServerConfig      `koanf:"server"`
-	Telemetry   TelemetryConfig   `koanf:"telemetry"`
-	Naming      NamingConfig      `koanf:"naming"`
-	Upstreams   []UpstreamConfig  `koanf:"upstreams"`
-	InboundAuth InboundAuthConfig `koanf:"inbound_auth"`
-	Groups      []GroupConfig     `koanf:"groups"`
-	Runtime     RuntimeConfig     `koanf:"runtime"`
+	Server        ServerConfig        `koanf:"server"`
+	Telemetry     TelemetryConfig     `koanf:"telemetry"`
+	Naming        NamingConfig        `koanf:"naming"`
+	Upstreams     []UpstreamConfig    `koanf:"upstreams"`
+	InboundAuth   InboundAuthConfig   `koanf:"inbound_auth"`
+	Groups        []GroupConfig       `koanf:"groups"`
+	Runtime       RuntimeConfig       `koanf:"runtime"`
+	TokenCounting TokenCountingConfig `koanf:"token_counting"`
+}
+
+// TokenCountingConfig configures per-tool token counting on tool results.
+// When enabled, successful tool call results are tokenized and the count is
+// recorded as a Prometheus histogram (mcp_tool_result_tokens).
+// When absent or enabled: false, no tokenization occurs.
+type TokenCountingConfig struct {
+	// Enabled activates token counting. Default: false.
+	Enabled bool `koanf:"enabled"`
+	// Encoding selects the tiktoken BPE encoding used for tokenization.
+	// Supported values: "cl100k_base" (default), "o200k_base".
+	Encoding string `koanf:"encoding"`
 }
 
 // RuntimeConfig controls the bounded pools for concurrent script runtime instances.

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gaarutyunov/mcp-anything/pkg/config"
 	"github.com/gaarutyunov/mcp-anything/pkg/runtime"
 	pkgtelemetry "github.com/gaarutyunov/mcp-anything/pkg/telemetry"
+	"github.com/gaarutyunov/mcp-anything/pkg/tokencounter"
 	pkgupstream "github.com/gaarutyunov/mcp-anything/pkg/upstream"
 )
 
@@ -42,7 +43,8 @@ type Manager struct {
 	impl     *sdkmcp.Implementation // set on first Rebuild
 	mu       sync.RWMutex
 
-	pools *runtime.Registry // for injecting runtime pools into upstream configs
+	pools   *runtime.Registry     // for injecting runtime pools into upstream configs
+	counter *tokencounter.Counter // nil when token counting is disabled
 
 	// State needed for per-upstream incremental updates (background refresh).
 	groups         []config.GroupConfig
@@ -177,6 +179,15 @@ func (m *Manager) Rebuild(ctx context.Context, cfg *config.ProxyConfig) error {
 		return fmt.Errorf("building tool registry: %w", err)
 	}
 
+	// Build token counter when enabled in config.
+	var newCounter *tokencounter.Counter
+	if cfg.TokenCounting.Enabled {
+		newCounter, err = tokencounter.New(cfg.TokenCounting.Encoding)
+		if err != nil {
+			slog.Warn("token counting disabled: could not initialise tokenizer", "error", err)
+		}
+	}
+
 	// Build per-upstream state map from the new registry.
 	newUpstreamByName := make(map[string]*upstreamState, len(validatedUpstreams))
 	for _, vu := range validatedUpstreams {
@@ -189,6 +200,7 @@ func (m *Manager) Rebuild(ctx context.Context, cfg *config.ProxyConfig) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	m.counter = newCounter
 	m.applyRegistryLocked(newRegistry, groups)
 
 	m.groups = groups
@@ -290,6 +302,19 @@ func (m *Manager) applyRegistryLocked(newRegistry *pkgupstream.Registry, groups 
 				}
 				if dispErr != nil {
 					span.RecordError(dispErr)
+				}
+
+				// Record token count for successful results (no error, non-nil counter).
+				if dispErr == nil && result != nil {
+					m.mu.RLock()
+					ctr := m.counter
+					reg := m.registry
+					m.mu.RUnlock()
+					upstreamName := ""
+					if reg != nil {
+						upstreamName = reg.ToolUpstreamName(t.Name)
+					}
+					ctr.Record(callCtx, t.Name, upstreamName, result)
 				}
 
 				return result, dispErr

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -11,6 +11,9 @@ import (
 // histogramBoundaries are the histogram bucket boundaries per SPEC.md §16.
 var histogramBoundaries = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
 
+// tokenBuckets are the histogram bucket boundaries for tool result token counts.
+var tokenBuckets = []float64{100, 500, 1000, 2000, 5000, 10000, 50000}
+
 // Metric instruments — initialised once at startup by InitMetrics.
 var (
 	// ToolCallDuration tracks MCP tool call duration.
@@ -23,6 +26,9 @@ var (
 	ConfigReloadCounter metric.Int64Counter
 	// SpecRefreshCounter counts spec refresh attempts by upstream and status.
 	SpecRefreshCounter metric.Int64Counter
+	// ToolResultTokens tracks the token count of tool result content.
+	// Labels: tool_name, upstream_name.
+	ToolResultTokens metric.Int64Histogram
 )
 
 // InitMetrics creates all MCP-specific metric instruments using the given provider.
@@ -72,6 +78,15 @@ func InitMetrics(mp metric.MeterProvider) error {
 	)
 	if err != nil {
 		return fmt.Errorf("creating mcp_anything.spec_refresh: %w", err)
+	}
+
+	ToolResultTokens, err = m.Int64Histogram("mcp_tool_result_tokens",
+		metric.WithUnit("{token}"),
+		metric.WithDescription("Token count of tool result content"),
+		metric.WithExplicitBucketBoundaries(tokenBuckets...),
+	)
+	if err != nil {
+		return fmt.Errorf("creating mcp_tool_result_tokens: %w", err)
 	}
 
 	return nil

--- a/pkg/tokencounter/tokencounter.go
+++ b/pkg/tokencounter/tokencounter.go
@@ -1,0 +1,96 @@
+// Package tokencounter tokenizes MCP tool result content and records the token
+// count to an OTel histogram. It is used by the MCP manager to provide
+// per-tool token count observability, helping operators identify which tools
+// return large responses and need a x-mcp-response-transform to slim them down.
+package tokencounter
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	tiktoken "github.com/pkoukk/tiktoken-go"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	pkgtelemetry "github.com/gaarutyunov/mcp-anything/pkg/telemetry"
+)
+
+// defaultEncoding is used when no encoding is specified in config.
+const defaultEncoding = "cl100k_base"
+
+// Counter tokenizes tool result content and records the token count to the
+// mcp_tool_result_tokens OTel histogram. A nil Counter is safe to use —
+// Record is a no-op on nil.
+type Counter struct {
+	enc *tiktoken.Tiktoken
+}
+
+// New creates a Counter using the given tiktoken BPE encoding name.
+// If encoding is empty, "cl100k_base" is used.
+// Returns an error if the encoding data cannot be loaded.
+func New(encoding string) (*Counter, error) {
+	if encoding == "" {
+		encoding = defaultEncoding
+	}
+	enc, err := tiktoken.GetEncoding(encoding)
+	if err != nil {
+		return nil, fmt.Errorf("loading tiktoken encoding %q: %w", encoding, err)
+	}
+	return &Counter{enc: enc}, nil
+}
+
+// Record tokenizes the content items in result and records the total token count
+// to the mcp_tool_result_tokens histogram with tool_name and upstream_name labels.
+//
+// It is a no-op when:
+//   - c is nil
+//   - result is nil
+//   - result.IsError is true (error results are not counted)
+//   - pkgtelemetry.ToolResultTokens is nil (metrics not initialised)
+func (c *Counter) Record(ctx context.Context, toolName, upstreamName string, result *sdkmcp.CallToolResult) {
+	if c == nil || result == nil || result.IsError {
+		return
+	}
+	if pkgtelemetry.ToolResultTokens == nil {
+		return
+	}
+
+	total := c.countContent(result.Content)
+
+	pkgtelemetry.ToolResultTokens.Record(ctx, int64(total), metric.WithAttributes(
+		attribute.String("tool_name", toolName),
+		attribute.String("upstream_name", upstreamName),
+	))
+}
+
+// countContent sums the token counts of all content items.
+func (c *Counter) countContent(content []sdkmcp.Content) int {
+	total := 0
+	for _, item := range content {
+		total += c.countItem(item)
+	}
+	return total
+}
+
+// countItem returns the token count for a single content item.
+func (c *Counter) countItem(item sdkmcp.Content) int {
+	switch v := item.(type) {
+	case *sdkmcp.TextContent:
+		return c.countString(v.Text)
+	case *sdkmcp.ImageContent:
+		return c.countString(base64.StdEncoding.EncodeToString(v.Data))
+	case *sdkmcp.AudioContent:
+		return c.countString(base64.StdEncoding.EncodeToString(v.Data))
+	default:
+		slog.Debug("tokencounter: skipping unsupported content type", "type", fmt.Sprintf("%T", item))
+		return 0
+	}
+}
+
+// countString tokenizes text and returns the token count.
+func (c *Counter) countString(text string) int {
+	return len(c.enc.Encode(text, nil, nil))
+}

--- a/pkg/tokencounter/tokencounter_test.go
+++ b/pkg/tokencounter/tokencounter_test.go
@@ -1,0 +1,167 @@
+package tokencounter_test
+
+import (
+	"context"
+	"testing"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	pkgtelemetry "github.com/gaarutyunov/mcp-anything/pkg/telemetry"
+	"github.com/gaarutyunov/mcp-anything/pkg/tokencounter"
+)
+
+func TestNew_DefaultEncoding(t *testing.T) {
+	c, err := tokencounter.New("")
+	if err != nil {
+		t.Fatalf("New(\"\") error: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil Counter")
+	}
+}
+
+func TestNew_Cl100kBase(t *testing.T) {
+	c, err := tokencounter.New("cl100k_base")
+	if err != nil {
+		t.Fatalf("New(cl100k_base) error: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil Counter")
+	}
+}
+
+func TestNew_O200kBase(t *testing.T) {
+	c, err := tokencounter.New("o200k_base")
+	if err != nil {
+		t.Fatalf("New(o200k_base) error: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil Counter")
+	}
+}
+
+func TestNew_UnknownEncoding(t *testing.T) {
+	_, err := tokencounter.New("bogus_encoding")
+	if err == nil {
+		t.Fatal("expected error for unknown encoding, got nil")
+	}
+}
+
+// TestRecord_NilCounter verifies that Record on a nil Counter is a no-op.
+func TestRecord_NilCounter(t *testing.T) {
+	initNoopHistogram(t)
+	var c *tokencounter.Counter
+	// Should not panic
+	c.Record(context.Background(), "tool", "upstream", &sdkmcp.CallToolResult{
+		Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "hello"}},
+	})
+}
+
+// TestRecord_NilResult verifies that Record with nil result is a no-op.
+func TestRecord_NilResult(t *testing.T) {
+	initNoopHistogram(t)
+	c, err := tokencounter.New("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should not panic
+	c.Record(context.Background(), "tool", "upstream", nil)
+}
+
+// TestRecord_ErrorResult verifies that error results are not counted.
+func TestRecord_ErrorResult(t *testing.T) {
+	initNoopHistogram(t)
+	c, err := tokencounter.New("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should not panic and should not record
+	c.Record(context.Background(), "tool", "upstream", &sdkmcp.CallToolResult{
+		IsError: true,
+		Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "an error occurred"}},
+	})
+}
+
+// TestRecord_TextContent verifies that TextContent is tokenized.
+func TestRecord_TextContent(t *testing.T) {
+	initNoopHistogram(t)
+	c, err := tokencounter.New("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A non-empty text should produce a positive token count (recorded without error).
+	c.Record(context.Background(), "mytool", "myupstream", &sdkmcp.CallToolResult{
+		Content: []sdkmcp.Content{
+			&sdkmcp.TextContent{Text: `{"pets":[{"id":1,"name":"Fluffy"}]}`},
+		},
+	})
+}
+
+// TestRecord_ImageContent verifies that ImageContent base64 payload is tokenized.
+func TestRecord_ImageContent(t *testing.T) {
+	initNoopHistogram(t)
+	c, err := tokencounter.New("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Record(context.Background(), "mytool", "myupstream", &sdkmcp.CallToolResult{
+		Content: []sdkmcp.Content{
+			&sdkmcp.ImageContent{Data: []byte("fake-image-data"), MIMEType: "image/png"},
+		},
+	})
+}
+
+// TestRecord_AudioContent verifies that AudioContent base64 payload is tokenized.
+func TestRecord_AudioContent(t *testing.T) {
+	initNoopHistogram(t)
+	c, err := tokencounter.New("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Record(context.Background(), "mytool", "myupstream", &sdkmcp.CallToolResult{
+		Content: []sdkmcp.Content{
+			&sdkmcp.AudioContent{Data: []byte("fake-audio-data"), MIMEType: "audio/mp3"},
+		},
+	})
+}
+
+// TestRecord_MultipleContentItems verifies that multiple content items are summed.
+func TestRecord_MultipleContentItems(t *testing.T) {
+	initNoopHistogram(t)
+	c, err := tokencounter.New("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Two text items — both should be counted together.
+	c.Record(context.Background(), "mytool", "myupstream", &sdkmcp.CallToolResult{
+		Content: []sdkmcp.Content{
+			&sdkmcp.TextContent{Text: "first item"},
+			&sdkmcp.TextContent{Text: "second item"},
+		},
+	})
+}
+
+// TestRecord_NoHistogram verifies that Record is a no-op when the histogram is nil.
+func TestRecord_NoHistogram(t *testing.T) {
+	// Reset histogram to nil to simulate uninitialized metrics.
+	pkgtelemetry.ToolResultTokens = nil
+	c, err := tokencounter.New("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should not panic
+	c.Record(context.Background(), "tool", "upstream", &sdkmcp.CallToolResult{
+		Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "hello"}},
+	})
+}
+
+// initNoopHistogram sets pkgtelemetry.ToolResultTokens to a noop histogram so
+// that Record does not panic due to a nil histogram.
+func initNoopHistogram(t *testing.T) {
+	t.Helper()
+	mp := noop.NewMeterProvider()
+	if err := pkgtelemetry.InitMetrics(mp); err != nil {
+		t.Fatalf("InitMetrics: %v", err)
+	}
+}

--- a/tests/integration/token_counting_test.go
+++ b/tests/integration/token_counting_test.go
@@ -1,0 +1,356 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/network"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// tokenCountingOpenAPISpec defines a minimal API used by token counting tests.
+const tokenCountingOpenAPISpec = `openapi: "3.0.0"
+info:
+  title: Token Counting Test API
+  version: "1.0"
+paths:
+  /data:
+    get:
+      operationId: getData
+      summary: Get data
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+`
+
+// tokenCountingProxyConfig returns a proxy config with token counting enabled.
+func tokenCountingProxyConfig(encoding string) string {
+	encodingLine := ""
+	if encoding != "" {
+		encodingLine = fmt.Sprintf("  encoding: %s\n", encoding)
+	}
+	return fmt.Sprintf(`server:
+  port: 8080
+naming:
+  separator: "__"
+telemetry:
+  service_name: mcp-anything
+  service_version: v0.0.0-test
+token_counting:
+  enabled: true
+%supstreams:
+  - name: tc
+    enabled: true
+    tool_prefix: tc
+    base_url: http://wiremock:8080
+    timeout: 10s
+    openapi:
+      source: /etc/mcp-anything/spec.yaml
+      version: "3.0"
+    validation:
+      success_status: [200]
+`, encodingLine)
+}
+
+// tokenCountingProxyConfigDisabled returns a proxy config with token counting disabled.
+func tokenCountingProxyConfigDisabled() string {
+	return `server:
+  port: 8080
+naming:
+  separator: "__"
+telemetry:
+  service_name: mcp-anything
+  service_version: v0.0.0-test
+upstreams:
+  - name: tc
+    enabled: true
+    tool_prefix: tc
+    base_url: http://wiremock:8080
+    timeout: 10s
+    openapi:
+      source: /etc/mcp-anything/spec.yaml
+      version: "3.0"
+    validation:
+      success_status: [200]
+`
+}
+
+func startTokenCountingProxy(ctx context.Context, t *testing.T, net *testcontainers.DockerNetwork, cfgContent string) (testcontainers.Container, string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	specPath := filepath.Join(tmpDir, "spec.yaml")
+	if err := os.WriteFile(specPath, []byte(tokenCountingOpenAPISpec), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	proxyReq := proxyContainerRequest()
+	proxyReq.ExposedPorts = []string{"8080/tcp"}
+	proxyReq.Networks = []string{net.Name}
+	proxyReq.Env = map[string]string{
+		"CONFIG_PATH": "/etc/mcp-anything/config.yaml",
+	}
+	proxyReq.Files = []testcontainers.ContainerFile{
+		{HostFilePath: cfgPath, ContainerFilePath: "/etc/mcp-anything/config.yaml", FileMode: 0o644},
+		{HostFilePath: specPath, ContainerFilePath: "/etc/mcp-anything/spec.yaml", FileMode: 0o644},
+	}
+	proxyReq.WaitingFor = wait.ForHTTP("/healthz").WithPort("8080").WithStartupTimeout(120 * time.Second)
+	proxy := startContainer(ctx, t, proxyReq)
+
+	host, err := proxy.Host(ctx)
+	if err != nil {
+		t.Fatalf("proxy host: %v", err)
+	}
+	port, err := proxy.MappedPort(ctx, "8080")
+	if err != nil {
+		t.Fatalf("proxy port: %v", err)
+	}
+	return proxy, fmt.Sprintf("http://%s:%s", host, port.Port())
+}
+
+// TestTokenCountingMetricEmitted verifies that with token_counting.enabled: true,
+// a successful tool call emits the mcp_tool_result_tokens histogram metric.
+func TestTokenCountingMetricEmitted(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	net, err := network.New(ctx, network.WithDriver("bridge"))
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() { _ = net.Remove(ctx) })
+
+	// Start WireMock with a known JSON response body.
+	wiremock := startContainer(ctx, t, testcontainers.ContainerRequest{
+		Image:        "wiremock/wiremock:3.9.1",
+		ExposedPorts: []string{"8080/tcp"},
+		Networks:     []string{net.Name},
+		NetworkAliases: map[string][]string{
+			net.Name: {"wiremock"},
+		},
+		WaitingFor: wait.ForHTTP("/__admin/mappings").WithPort("8080").WithStartupTimeout(60 * time.Second),
+	})
+	wmHost, _ := wiremock.Host(ctx)
+	wmPort, _ := wiremock.MappedPort(ctx, "8080")
+	wmURL := fmt.Sprintf("http://%s:%s", wmHost, wmPort.Port())
+
+	// Register a stub that returns a known JSON response (~15 tokens).
+	registerStub(t, wmURL, `{
+		"request": {"method": "GET", "url": "/data"},
+		"response": {
+			"status": 200,
+			"body": "{\"result\":\"hello world this is a test response\"}",
+			"headers": {"Content-Type": "application/json"}
+		}
+	}`)
+
+	// Start proxy with token counting enabled (default cl100k_base encoding).
+	_, proxyURL := startTokenCountingProxy(ctx, t, net, tokenCountingProxyConfig(""))
+
+	// Connect MCP client and make a tool call.
+	transport := &sdkmcp.StreamableClientTransport{Endpoint: proxyURL + "/mcp"}
+	mcpClient := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "tc-test-client", Version: "v0.0.1"}, nil)
+	callCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	session, err := mcpClient.Connect(callCtx, transport, nil)
+	if err != nil {
+		t.Fatalf("connect MCP client: %v", err)
+	}
+	defer session.Close()
+
+	result, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{Name: "tc__getdata"})
+	if err != nil {
+		t.Fatalf("call tc__getdata: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %s", contentText(result.Content))
+	}
+
+	// Fetch Prometheus metrics and assert the token histogram is present.
+	resp, err := http.Get(proxyURL + "/metrics") //nolint:noctx
+	if err != nil {
+		t.Fatalf("GET /metrics: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read /metrics: %v", err)
+	}
+	metrics := string(body)
+	t.Logf("/metrics (first 3000 chars): %.3000s", metrics)
+
+	if !strings.Contains(metrics, "mcp_tool_result_tokens_bucket") {
+		t.Errorf("expected mcp_tool_result_tokens_bucket in /metrics; token counting not emitting histogram")
+	}
+	if !strings.Contains(metrics, `tool_name="tc__getdata"`) {
+		t.Errorf("expected tool_name label in mcp_tool_result_tokens metric")
+	}
+	if !strings.Contains(metrics, `upstream_name="tc"`) {
+		t.Errorf("expected upstream_name label in mcp_tool_result_tokens metric")
+	}
+}
+
+// TestTokenCountingDisabledNoMetric verifies that when token counting is absent
+// from the config, the mcp_tool_result_tokens histogram has no observations.
+func TestTokenCountingDisabledNoMetric(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	net, err := network.New(ctx, network.WithDriver("bridge"))
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() { _ = net.Remove(ctx) })
+
+	wiremock := startContainer(ctx, t, testcontainers.ContainerRequest{
+		Image:        "wiremock/wiremock:3.9.1",
+		ExposedPorts: []string{"8080/tcp"},
+		Networks:     []string{net.Name},
+		NetworkAliases: map[string][]string{
+			net.Name: {"wiremock"},
+		},
+		WaitingFor: wait.ForHTTP("/__admin/mappings").WithPort("8080").WithStartupTimeout(60 * time.Second),
+	})
+	wmHost, _ := wiremock.Host(ctx)
+	wmPort, _ := wiremock.MappedPort(ctx, "8080")
+	wmURL := fmt.Sprintf("http://%s:%s", wmHost, wmPort.Port())
+
+	registerStub(t, wmURL, `{
+		"request": {"method": "GET", "url": "/data"},
+		"response": {
+			"status": 200,
+			"body": "{\"result\":\"hello\"}",
+			"headers": {"Content-Type": "application/json"}
+		}
+	}`)
+
+	_, proxyURL := startTokenCountingProxy(ctx, t, net, tokenCountingProxyConfigDisabled())
+
+	transport := &sdkmcp.StreamableClientTransport{Endpoint: proxyURL + "/mcp"}
+	mcpClient := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "tc-disabled-client", Version: "v0.0.1"}, nil)
+	callCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	session, err := mcpClient.Connect(callCtx, transport, nil)
+	if err != nil {
+		t.Fatalf("connect MCP client: %v", err)
+	}
+	defer session.Close()
+
+	result, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{Name: "tc__getdata"})
+	if err != nil {
+		t.Fatalf("call tc__getdata: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %s", contentText(result.Content))
+	}
+
+	resp, err := http.Get(proxyURL + "/metrics") //nolint:noctx
+	if err != nil {
+		t.Fatalf("GET /metrics: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read /metrics: %v", err)
+	}
+	metrics := string(body)
+
+	// The histogram is always registered, but should have no observations (count == 0).
+	// With no observations, the _bucket lines will appear but the _count should be 0 or absent.
+	if strings.Contains(metrics, `mcp_tool_result_tokens_count{`) &&
+		strings.Contains(metrics, `upstream_name="tc"`) {
+		t.Errorf("expected no mcp_tool_result_tokens observations when token counting is disabled")
+	}
+}
+
+// TestTokenCountingO200kEncoding verifies that the o200k_base encoding works.
+func TestTokenCountingO200kEncoding(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	net, err := network.New(ctx, network.WithDriver("bridge"))
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() { _ = net.Remove(ctx) })
+
+	wiremock := startContainer(ctx, t, testcontainers.ContainerRequest{
+		Image:        "wiremock/wiremock:3.9.1",
+		ExposedPorts: []string{"8080/tcp"},
+		Networks:     []string{net.Name},
+		NetworkAliases: map[string][]string{
+			net.Name: {"wiremock"},
+		},
+		WaitingFor: wait.ForHTTP("/__admin/mappings").WithPort("8080").WithStartupTimeout(60 * time.Second),
+	})
+	wmHost, _ := wiremock.Host(ctx)
+	wmPort, _ := wiremock.MappedPort(ctx, "8080")
+	wmURL := fmt.Sprintf("http://%s:%s", wmHost, wmPort.Port())
+
+	registerStub(t, wmURL, `{
+		"request": {"method": "GET", "url": "/data"},
+		"response": {
+			"status": 200,
+			"body": "{\"result\":\"hello world\"}",
+			"headers": {"Content-Type": "application/json"}
+		}
+	}`)
+
+	_, proxyURL := startTokenCountingProxy(ctx, t, net, tokenCountingProxyConfig("o200k_base"))
+
+	transport := &sdkmcp.StreamableClientTransport{Endpoint: proxyURL + "/mcp"}
+	mcpClient := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "tc-o200k-client", Version: "v0.0.1"}, nil)
+	callCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	session, err := mcpClient.Connect(callCtx, transport, nil)
+	if err != nil {
+		t.Fatalf("connect MCP client: %v", err)
+	}
+	defer session.Close()
+
+	result, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{Name: "tc__getdata"})
+	if err != nil {
+		t.Fatalf("call tc__getdata: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %s", contentText(result.Content))
+	}
+
+	resp, err := http.Get(proxyURL + "/metrics") //nolint:noctx
+	if err != nil {
+		t.Fatalf("GET /metrics: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read /metrics: %v", err)
+	}
+	metrics := string(body)
+	t.Logf("/metrics (first 3000 chars): %.3000s", metrics)
+
+	if !strings.Contains(metrics, "mcp_tool_result_tokens_bucket") {
+		t.Errorf("expected mcp_tool_result_tokens_bucket in /metrics with o200k_base encoding")
+	}
+}


### PR DESCRIPTION
Implements opt-in token counting on MCP tool result content using tiktoken-go (cl100k_base/o200k_base BPE encodings). Token counts are exposed as a Prometheus histogram mcp_tool_result_tokens with tool_name and upstream_name labels, helping operators identify which tools return large responses that need a response transform.

Closes #85

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added token counting capability for MCP tool results with per-tool and per-upstream observability
  * New Prometheus histogram metric to track and monitor token usage
  * Configuration options to enable/disable token counting and select tokenization encoding (supports `cl100k_base`, `o200k_base`, and custom encodings)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->