### PR TITLE
feat: Helm chart release — move to charts/, OCI publishing, integration test

### DIFF
--- a/.cr.yaml
+++ b/.cr.yaml
@@ -1,0 +1,5 @@
+## chart-releaser configuration
+## See: https://helm.sh/docs/howto/chart_releaser_action/
+charts-dir: charts
+pages-branch: gh-pages
+packages-with-index: false

--- a/.cr.yaml
+++ b/.cr.yaml
@@ -1,5 +1,0 @@
-## chart-releaser configuration
-## See: https://helm.sh/docs/howto/chart_releaser_action/
-charts-dir: charts
-pages-branch: gh-pages
-packages-with-index: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   GOWORK: off
+  OPERATOR_IMAGE: ghcr.io/${{ github.repository }}-operator:sha-${{ github.sha }}
   PROXY_IMAGE: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
   CADDY_IMAGE: ghcr.io/${{ github.repository }}:caddy-sha-${{ github.sha }}
 
@@ -88,10 +89,34 @@ jobs:
           push: true
           tags: ${{ env.CADDY_IMAGE }}
 
+  build-operator-image:
+    name: Build & Push Operator Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.operator
+          push: true
+          tags: ${{ env.OPERATOR_IMAGE }}
+
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
-    needs: [lint-and-test, build-image, build-caddy-image]
+    needs: [lint-and-test, build-image, build-caddy-image, build-operator-image]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,33 @@ jobs:
       - name: Build
         run: go build ./...
 
+  push-helm-chart:
+    name: Push Helm Chart (OCI)
+    runs-on: ubuntu-latest
+    needs: [lint-and-test]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.17.3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package and push chart
+        run: |
+          helm package charts/mcp-anything --version "0.0.0-sha.${{ github.sha }}" --app-version "${{ github.sha }}"
+          helm push mcp-anything-0.0.0-sha.${{ github.sha }}.tgz oci://ghcr.io/${{ github.repository_owner }}
+
   build-image:
     name: Build & Push Image
     runs-on: ubuntu-latest
@@ -116,7 +143,7 @@ jobs:
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
-    needs: [lint-and-test, build-image, build-caddy-image, build-operator-image]
+    needs: [lint-and-test, build-image, build-caddy-image, build-operator-image, push-helm-chart]
     steps:
       - uses: actions/checkout@v4
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,22 @@ builds:
       - amd64
       - arm64
 
+  - id: operator
+    main: ./cmd/operator
+    binary: operator
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
 archives:
   - id: default
     formats:
@@ -41,6 +57,17 @@ dockers_v2:
       - linux/amd64
       - linux/arm64
     dockerfile: Dockerfile.goreleaser
+
+  - ids: [operator]
+    images:
+      - "ghcr.io/gaarutyunov/mcp-anything-operator"
+    tags:
+      - "{{ .Version }}"
+      - "latest"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    dockerfile: Dockerfile.operator.goreleaser
 
 helm_charts:
   - name: mcp-anything

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,15 @@ dockers_v2:
       - linux/arm64
     dockerfile: Dockerfile.goreleaser
 
+helm_charts:
+  - name: mcp-anything
+    dir: charts/mcp-anything
+    chart_version: "{{ .Version }}"
+    app_version: "{{ .Version }}"
+    oci:
+      - host: ghcr.io
+        owner: gaarutyunov
+
 checksum:
   name_template: "checksums.txt"
 

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -1,0 +1,12 @@
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /operator ./cmd/operator
+
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /operator /usr/local/bin/operator
+ENTRYPOINT ["operator"]

--- a/Dockerfile.operator.goreleaser
+++ b/Dockerfile.operator.goreleaser
@@ -1,16 +1,10 @@
-FROM golang:1.25-alpine AS builder
-
-WORKDIR /src
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
-RUN CGO_ENABLED=0 go build -o /operator ./cmd/operator
-
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates \
     && addgroup -S operator \
     && adduser -S -G operator operator
-COPY --from=builder /operator /usr/local/bin/operator
+ARG TARGETOS
+ARG TARGETARCH
+COPY ${TARGETOS}/${TARGETARCH}/operator /usr/local/bin/operator
 RUN chown operator:operator /usr/local/bin/operator
 USER operator:operator
 ENTRYPOINT ["operator"]

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
-.PHONY: build build-operator lint vet test integration check clean
+.PHONY: build build-operator lint vet test integration check clean helm-lint helm-package helm-push
 
 BINARY := bin/proxy
 OPERATOR_BINARY := bin/operator
 GOFLAGS := -race
 INTEGRATION_TIMEOUT := 600s
+
+HELM_CHART_DIR := charts/mcp-anything
+HELM_DIST_DIR := dist
+HELM_REGISTRY ?= oci://ghcr.io/gaarutyunov
 
 build:
 	go build -o $(BINARY) ./cmd/proxy
@@ -27,3 +31,13 @@ check: lint vet test build build-operator
 
 clean:
 	rm -rf bin/
+
+helm-lint:
+	helm lint $(HELM_CHART_DIR)
+
+helm-package:
+	mkdir -p $(HELM_DIST_DIR)
+	helm package $(HELM_CHART_DIR) --destination $(HELM_DIST_DIR)
+
+helm-push: helm-package
+	helm push $(HELM_DIST_DIR)/mcp-anything-*.tgz $(HELM_REGISTRY)

--- a/charts/mcp-anything/Chart.yaml
+++ b/charts/mcp-anything/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: mcp-anything
+description: Kubernetes operator for mcp-anything — converts HTTP REST APIs into MCP tools via CRDs.
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - mcp
+  - operator
+  - kubernetes
+  - api-gateway
+home: https://github.com/gaarutyunov/mcp-anything
+sources:
+  - https://github.com/gaarutyunov/mcp-anything
+maintainers:
+  - name: gaarutyunov

--- a/charts/mcp-anything/crds/mcpproxy.yaml
+++ b/charts/mcp-anything/crds/mcpproxy.yaml
@@ -1,0 +1,200 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mcpproxies.mcp-anything.ai
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+spec:
+  group: mcp-anything.ai
+  names:
+    kind: MCPProxy
+    listKind: MCPProxyList
+    plural: mcpproxies
+    singular: mcpproxy
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: MCPProxy is the Schema for the mcpproxies API.
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              description: MCPProxySpec defines the desired state of MCPProxy.
+              properties:
+                upstreamSelector:
+                  type: object
+                  description: UpstreamSelector selects MCPUpstream resources by label.
+                  properties:
+                    matchLabels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    matchExpressions:
+                      type: array
+                      items:
+                        type: object
+                        required: [key, operator]
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: string
+                namespaceSelector:
+                  type: object
+                  description: NamespaceSelector restricts which namespaces are searched.
+                  properties:
+                    matchNames:
+                      type: array
+                      items:
+                        type: string
+                serviceDiscovery:
+                  type: object
+                  description: ServiceDiscovery configures annotation-based upstream discovery from Services.
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: Enabled enables scanning for annotated Services.
+                    namespaceSelector:
+                      type: object
+                      description: NamespaceSelector restricts which namespaces are scanned for annotated Services.
+                      properties:
+                        matchNames:
+                          type: array
+                          items:
+                            type: string
+                        matchLabels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                replicas:
+                  type: integer
+                  format: int32
+                  minimum: 1
+                  description: Replicas is the number of proxy pod replicas.
+                image:
+                  type: string
+                  description: Image is the proxy container image.
+                resources:
+                  type: object
+                  description: Resources defines CPU/memory requirements.
+                  properties:
+                    limits:
+                      type: object
+                      additionalProperties:
+                        type: string
+                    requests:
+                      type: object
+                      additionalProperties:
+                        type: string
+                server:
+                  type: object
+                  description: Server configures the MCP server endpoint.
+                  properties:
+                    port:
+                      type: integer
+                      format: int32
+                      minimum: 1
+                      maximum: 65535
+                    transport:
+                      type: array
+                      items:
+                        type: string
+                    tls:
+                      type: object
+                      required: [secretName]
+                      properties:
+                        secretName:
+                          type: string
+                naming:
+                  type: object
+                  description: Naming configures tool name generation.
+                  properties:
+                    separator:
+                      type: string
+                    maxLength:
+                      type: integer
+                    conflictResolution:
+                      type: string
+                      enum: [error, truncate, hash]
+                inboundAuth:
+                  type: object
+                  description: InboundAuth configures inbound MCP client authentication.
+                  required: [strategy]
+                  properties:
+                    strategy:
+                      type: string
+                      enum: [jwt, none]
+                    jwt:
+                      type: object
+                      required: [jwksUrl]
+                      properties:
+                        jwksUrl:
+                          type: string
+                telemetry:
+                  type: object
+                  description: Telemetry configures observability settings.
+                  required: [enabled]
+                  properties:
+                    enabled:
+                      type: boolean
+                    otlpEndpoint:
+                      type: string
+            status:
+              type: object
+              description: MCPProxyStatus defines the observed state of MCPProxy.
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [lastTransitionTime, message, reason, status, type]
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                upstreamCount:
+                  type: integer
+                annotatedServiceCount:
+                  type: integer
+                toolCount:
+                  type: integer
+                observedGeneration:
+                  type: integer
+                  format: int64
+      additionalPrinterColumns:
+        - name: Upstreams
+          type: integer
+          jsonPath: .status.upstreamCount
+        - name: Tools
+          type: integer
+          jsonPath: .status.toolCount
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/charts/mcp-anything/crds/mcpupstream.yaml
+++ b/charts/mcp-anything/crds/mcpupstream.yaml
@@ -1,0 +1,160 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mcpupstreams.mcp-anything.ai
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+spec:
+  group: mcp-anything.ai
+  names:
+    kind: MCPUpstream
+    listKind: MCPUpstreamList
+    plural: mcpupstreams
+    singular: mcpupstream
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: MCPUpstream is the Schema for the mcpupstreams API.
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              description: MCPUpstreamSpec defines the desired state of MCPUpstream.
+              required: [openapi]
+              properties:
+                toolPrefix:
+                  type: string
+                  description: ToolPrefix is prepended to all tool names from this upstream.
+                serviceRef:
+                  type: object
+                  description: ServiceRef references an in-cluster Kubernetes Service.
+                  required: [name, port]
+                  properties:
+                    name:
+                      type: string
+                    port:
+                      type: integer
+                      format: int32
+                      minimum: 1
+                      maximum: 65535
+                baseURL:
+                  type: string
+                  description: BaseURL is the base URL for the upstream HTTP API.
+                openapi:
+                  type: object
+                  description: OpenAPI configures the OpenAPI spec source.
+                  properties:
+                    configMapRef:
+                      type: object
+                      required: [name, key]
+                      properties:
+                        name:
+                          type: string
+                        key:
+                          type: string
+                    url:
+                      type: string
+                    autoDiscover:
+                      type: object
+                      properties:
+                        path:
+                          type: string
+                overlay:
+                  type: object
+                  description: Overlay configures an optional OpenAPI Overlay document.
+                  properties:
+                    configMapRef:
+                      type: object
+                      required: [name, key]
+                      properties:
+                        name:
+                          type: string
+                        key:
+                          type: string
+                outboundAuth:
+                  type: object
+                  description: OutboundAuth configures authentication for outbound requests.
+                  required: [strategy]
+                  properties:
+                    strategy:
+                      type: string
+                      enum: [bearer, oauth2_client_credentials, none]
+                    oauth2:
+                      type: object
+                      required: [tokenURL]
+                      properties:
+                        tokenURL:
+                          type: string
+                        secretRef:
+                          type: object
+                          required: [name]
+                          properties:
+                            name:
+                              type: string
+                transport:
+                  type: object
+                  description: Transport configures HTTP transport settings.
+                  properties:
+                    maxIdleConns:
+                      type: integer
+                    tls:
+                      type: object
+                      required: [secretName]
+                      properties:
+                        secretName:
+                          type: string
+                validation:
+                  type: object
+                  description: Validation configures request/response validation.
+                  properties:
+                    validateRequest:
+                      type: boolean
+                    validateResponse:
+                      type: boolean
+            status:
+              type: object
+              description: MCPUpstreamStatus defines the observed state of MCPUpstream.
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [lastTransitionTime, message, reason, status, type]
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                assignedProxy:
+                  type: string
+                toolCount:
+                  type: integer
+      additionalPrinterColumns:
+        - name: Proxy
+          type: string
+          jsonPath: .status.assignedProxy
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/charts/mcp-anything/templates/_helpers.tpl
+++ b/charts/mcp-anything/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mcp-anything.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "mcp-anything.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label.
+*/}}
+{{- define "mcp-anything.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "mcp-anything.labels" -}}
+helm.sh/chart: {{ include "mcp-anything.chart" . }}
+{{ include "mcp-anything.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "mcp-anything.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-anything.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: operator
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "mcp-anything.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mcp-anything.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/mcp-anything/templates/deployment.yaml
+++ b/charts/mcp-anything/templates/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-anything.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-anything.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mcp-anything.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mcp-anything.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mcp-anything.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: operator
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --metrics-bind-address=:{{ .Values.metrics.port }}
+            - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+            {{- if .Values.leaderElect }}
+            - --leader-elect
+            {{- end }}
+            {{- if .Values.watchNamespace }}
+            - --namespace={{ .Values.watchNamespace }}
+            {{- end }}
+            {{- if .Values.webhooks.enabled }}
+            - --enable-webhooks
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            - name: health
+              containerPort: {{ .Values.healthProbe.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/mcp-anything/templates/rbac.yaml
+++ b/charts/mcp-anything/templates/rbac.yaml
@@ -1,0 +1,79 @@
+{{- $clusterScoped := eq .Values.watchNamespace "" -}}
+{{- $saName := include "mcp-anything.serviceAccountName" . -}}
+---
+{{- if $clusterScoped }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "mcp-anything.fullname" . }}
+  labels:
+    {{- include "mcp-anything.labels" . | nindent 4 }}
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "mcp-anything.fullname" . }}
+  namespace: {{ .Values.watchNamespace }}
+  labels:
+    {{- include "mcp-anything.labels" . | nindent 4 }}
+{{- end }}
+rules:
+  - apiGroups: [mcp-anything.ai]
+    resources: [mcpproxies, mcpupstreams]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [mcp-anything.ai]
+    resources: [mcpproxies/status, mcpupstreams/status]
+    verbs: [get, update, patch]
+  - apiGroups: [mcp-anything.ai]
+    resources: [mcpproxies/finalizers, mcpupstreams/finalizers]
+    verbs: [update]
+  - apiGroups: [""]
+    resources: [configmaps, services]
+    verbs: [get, list, watch, create, update, patch, delete]
+{{- if $clusterScoped }}
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [get, list, watch]
+{{- end }}
+  - apiGroups: [apps]
+    resources: [deployments]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [create, patch]
+  - apiGroups: [coordination.k8s.io]
+    resources: [leases]
+    verbs: [get, list, watch, create, update, patch, delete]
+---
+{{- if $clusterScoped }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "mcp-anything.fullname" . }}
+  labels:
+    {{- include "mcp-anything.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "mcp-anything.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ .Release.Namespace }}
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "mcp-anything.fullname" . }}
+  namespace: {{ .Values.watchNamespace }}
+  labels:
+    {{- include "mcp-anything.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "mcp-anything.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/mcp-anything/templates/serviceaccount.yaml
+++ b/charts/mcp-anything/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mcp-anything.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-anything.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mcp-anything/values.yaml
+++ b/charts/mcp-anything/values.yaml
@@ -1,0 +1,58 @@
+## mcp-anything operator Helm chart values.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/gaarutyunov/mcp-anything-operator
+  pullPolicy: IfNotPresent
+  tag: ""  # defaults to .Chart.AppVersion
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+  readOnlyRootFilesystem: true
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
+
+# Watch only this namespace. Empty = all namespaces (requires ClusterRole).
+watchNamespace: ""
+
+leaderElect: true
+
+webhooks:
+  enabled: false
+  certManager: false
+
+metrics:
+  enabled: true
+  port: 8443
+
+healthProbe:
+  port: 8081
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/tests/integration/helm_test.go
+++ b/tests/integration/helm_test.go
@@ -3,13 +3,17 @@
 package integration_test
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -48,10 +52,7 @@ const (
 // image to be pre-loaded into k3s. The test verifies that the CRDs and the
 // operator Deployment resource are created by the chart.
 func TestHelmChartInstall(t *testing.T) {
-	helmPath, err := exec.LookPath("helm")
-	if err != nil {
-		t.Skip("helm binary not found; install helm to run this test")
-	}
+	helmPath := ensureHelm(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), helmInstallTimeout)
 	defer cancel()
@@ -175,6 +176,89 @@ func resolveChartRef(ctx context.Context, t *testing.T, helmPath string) (ref, v
 	slog.Info("helm: chart pushed")
 
 	return fmt.Sprintf("oci://%s/mcp-anything", registryAddr), chartVer, reg
+}
+
+// ensureHelm returns the path to a helm binary. If helm is already on PATH it is
+// returned immediately. Otherwise it downloads the appropriate release from
+// get.helm.sh into a temp directory that is cleaned up when the test ends, so
+// the test never skips just because the CI runner lacks a pre-installed helm.
+func ensureHelm(t *testing.T) string {
+	t.Helper()
+
+	if p, err := exec.LookPath("helm"); err == nil {
+		return p
+	}
+
+	const helmVersion = "3.17.3"
+	goos := runtime.GOOS
+	goarch := runtime.GOARCH
+
+	archiveName := fmt.Sprintf("helm-v%s-%s-%s.tar.gz", helmVersion, goos, goarch)
+	dlURL := "https://get.helm.sh/" + archiveName
+	t.Logf("helm not found in PATH; downloading %s", dlURL)
+
+	dlCtx, dlCancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer dlCancel()
+
+	req, err := http.NewRequestWithContext(dlCtx, http.MethodGet, dlURL, nil)
+	if err != nil {
+		t.Fatalf("ensureHelm: build request: %v", err)
+	}
+	httpClient := &http.Client{Timeout: 3 * time.Minute}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("ensureHelm: download: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ensureHelm: unexpected HTTP status %s", resp.Status)
+	}
+
+	tmpDir := t.TempDir()
+	helmBin := filepath.Join(tmpDir, "helm")
+	if err := extractHelmBinary(resp.Body, goos+"-"+goarch, helmBin); err != nil {
+		t.Fatalf("ensureHelm: extract: %v", err)
+	}
+	if err := os.Chmod(helmBin, 0o755); err != nil {
+		t.Fatalf("ensureHelm: chmod: %v", err)
+	}
+	t.Logf("helm installed at %s", helmBin)
+	return helmBin
+}
+
+// extractHelmBinary reads a .tar.gz archive and writes the "helm" binary from
+// the directory named prefix (e.g. "linux-amd64") to dst.
+func extractHelmBinary(r io.Reader, prefix, dst string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	target := prefix + "/helm"
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar next: %w", err)
+		}
+		if hdr.Name != target {
+			continue
+		}
+		f, err := os.Create(dst)
+		if err != nil {
+			return fmt.Errorf("create: %w", err)
+		}
+		if _, err := io.Copy(f, tr); err != nil { //nolint:gosec // size bounded by helm release
+			f.Close()
+			return fmt.Errorf("copy: %w", err)
+		}
+		return f.Close()
+	}
+	return fmt.Errorf("helm binary not found in archive (expected %q)", target)
 }
 
 // parseChartVersion extracts the version from a packaged chart filename.

--- a/tests/integration/helm_test.go
+++ b/tests/integration/helm_test.go
@@ -1,0 +1,262 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testcontainers "github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/k3s"
+	tcwait "github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	helmInstallTimeout = 5 * time.Minute
+	helmReleaseNS      = "mcp-anything-system"
+	helmReleaseName    = "mcp-anything"
+)
+
+// TestHelmChartInstall verifies that the mcp-anything Helm chart can be installed
+// from an OCI registry into a k3s cluster.
+//
+// If HELM_CHART_IMAGE is set, the chart is pulled from that OCI reference directly.
+// This is used in CI after a sha-based chart has been pushed to GHCR:
+//
+//	HELM_CHART_IMAGE=oci://ghcr.io/gaarutyunov/mcp-anything
+//	HELM_CHART_VERSION=sha-<sha>
+//
+// Otherwise, the chart is packaged from charts/mcp-anything and pushed to a
+// temporary local registry started with testcontainers, then installed from there.
+//
+// In both cases, --wait=false is used so the test does not require the operator
+// image to be pre-loaded into k3s. The test verifies that the CRDs and the
+// operator Deployment resource are created by the chart.
+func TestHelmChartInstall(t *testing.T) {
+	helmPath, err := exec.LookPath("helm")
+	if err != nil {
+		t.Skip("helm binary not found; install helm to run this test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), helmInstallTimeout)
+	defer cancel()
+
+	chartRef, chartVersion, registryCtr := resolveChartRef(ctx, t, helmPath)
+	if registryCtr != nil {
+		t.Cleanup(func() {
+			if err := testcontainers.TerminateContainer(registryCtr); err != nil {
+				t.Logf("terminate local registry: %v", err)
+			}
+		})
+	}
+
+	// Start a fresh k3s cluster for this test (not the shared globalK3s — helm
+	// installs CRDs via the chart; the shared cluster already has CRDs loaded
+	// from manifests and mixing both would complicate cleanup).
+	slog.Info("helm: starting k3s cluster")
+	start := time.Now()
+	k3sCtr, err := k3s.Run(ctx, k3sImage)
+	if err != nil {
+		t.Fatalf("starting k3s: %v", err)
+	}
+	slog.Info("helm: k3s ready", "elapsed", time.Since(start).Round(time.Millisecond))
+	t.Cleanup(func() {
+		if err := testcontainers.TerminateContainer(k3sCtr); err != nil {
+			t.Logf("terminate k3s: %v", err)
+		}
+	})
+
+	// Write kubeconfig to a temp file so helm can use it.
+	kubeConfigYAML, err := k3sCtr.GetKubeConfig(ctx)
+	if err != nil {
+		t.Fatalf("getting kubeconfig: %v", err)
+	}
+	kubeconfigFile := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := os.WriteFile(kubeconfigFile, kubeConfigYAML, 0o600); err != nil {
+		t.Fatalf("writing kubeconfig: %v", err)
+	}
+
+	// Install the chart via helm.
+	helmInstall(ctx, t, helmPath, kubeconfigFile, chartRef, chartVersion, registryCtr != nil)
+
+	// Verify the chart installation using the k8s client.
+	verifyHelmRelease(ctx, t, kubeConfigYAML)
+}
+
+// resolveChartRef returns the OCI chart reference to install, the chart version,
+// and an optional local registry container. If HELM_CHART_IMAGE is set it is used
+// directly. Otherwise a local registry is started and the chart is packaged and pushed.
+func resolveChartRef(ctx context.Context, t *testing.T, helmPath string) (ref, version string, registryCtr testcontainers.Container) {
+	t.Helper()
+
+	if img := os.Getenv("HELM_CHART_IMAGE"); img != "" {
+		ver := os.Getenv("HELM_CHART_VERSION")
+		slog.Info("helm: using pre-built chart", "ref", img, "version", ver)
+		return img, ver, nil
+	}
+
+	slog.Info("helm: HELM_CHART_IMAGE not set; starting local OCI registry")
+	reg, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "registry:2",
+			ExposedPorts: []string{"5000/tcp"},
+			WaitingFor: tcwait.ForHTTP("/v2/").
+				WithPort("5000").
+				WithStatusCodeMatcher(func(status int) bool { return status == http.StatusOK }).
+				WithStartupTimeout(60 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("starting local registry: %v", err)
+	}
+
+	host, err := reg.Host(ctx)
+	if err != nil {
+		_ = testcontainers.TerminateContainer(reg)
+		t.Fatalf("getting registry host: %v", err)
+	}
+	port, err := reg.MappedPort(ctx, "5000")
+	if err != nil {
+		_ = testcontainers.TerminateContainer(reg)
+		t.Fatalf("getting registry port: %v", err)
+	}
+	registryAddr := fmt.Sprintf("%s:%s", host, port.Port())
+	slog.Info("helm: local registry ready", "addr", registryAddr)
+
+	// Package the chart from the repo root.
+	repoRoot := filepath.Join("..", "..")
+	chartDir := filepath.Join(repoRoot, "charts", "mcp-anything")
+	tmpDir := t.TempDir()
+
+	slog.Info("helm: packaging chart", "dir", chartDir)
+	out, err := exec.CommandContext(ctx, helmPath, "package", chartDir, "--destination", tmpDir).CombinedOutput()
+	if err != nil {
+		_ = testcontainers.TerminateContainer(reg)
+		t.Fatalf("helm package: %v\n%s", err, out)
+	}
+
+	// Find the packaged .tgz and extract the chart version from its filename.
+	matches, err := filepath.Glob(filepath.Join(tmpDir, "*.tgz"))
+	if err != nil || len(matches) == 0 {
+		_ = testcontainers.TerminateContainer(reg)
+		t.Fatalf("no chart tgz found after helm package in %s", tmpDir)
+	}
+	chartTgz := matches[0]
+	chartVer := parseChartVersion(filepath.Base(chartTgz))
+	slog.Info("helm: chart packaged", "file", filepath.Base(chartTgz), "version", chartVer)
+
+	// Push to the local registry using plain HTTP.
+	slog.Info("helm: pushing chart to local registry", "addr", registryAddr)
+	out, err = exec.CommandContext(ctx, helmPath,
+		"push", chartTgz,
+		fmt.Sprintf("oci://%s", registryAddr),
+		"--plain-http",
+	).CombinedOutput()
+	if err != nil {
+		_ = testcontainers.TerminateContainer(reg)
+		t.Fatalf("helm push: %v\n%s", err, out)
+	}
+	slog.Info("helm: chart pushed")
+
+	return fmt.Sprintf("oci://%s/mcp-anything", registryAddr), chartVer, reg
+}
+
+// parseChartVersion extracts the version from a packaged chart filename.
+// For example "mcp-anything-0.1.0.tgz" → "0.1.0".
+func parseChartVersion(filename string) string {
+	name := strings.TrimSuffix(filename, ".tgz")
+	idx := strings.LastIndex(name, "-")
+	if idx < 0 {
+		return ""
+	}
+	return name[idx+1:]
+}
+
+// helmInstall runs "helm install" to deploy the mcp-anything chart from the
+// given OCI reference into the helmReleaseNS namespace of the k3s cluster.
+func helmInstall(ctx context.Context, t *testing.T, helmPath, kubeconfigFile, chartRef, chartVersion string, plainHTTP bool) {
+	t.Helper()
+
+	args := []string{
+		"install", helmReleaseName, chartRef,
+		"--kubeconfig", kubeconfigFile,
+		"--namespace", helmReleaseNS,
+		"--create-namespace",
+		// Do not wait for pods — the operator image is not loaded into k3s.
+		"--wait=false",
+		// Disable leader election to avoid needing extra RBAC for the lease.
+		"--set", "leaderElect=false",
+	}
+	if chartVersion != "" {
+		args = append(args, "--version", chartVersion)
+	}
+	if plainHTTP {
+		args = append(args, "--plain-http")
+	}
+
+	slog.Info("helm: installing chart", "ref", chartRef, "namespace", helmReleaseNS)
+	out, err := exec.CommandContext(ctx, helmPath, args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("helm install: %v\n%s", err, out)
+	}
+	slog.Info("helm: install complete", "output", strings.TrimSpace(string(out)))
+}
+
+// verifyHelmRelease uses the k8s client to assert that the Helm chart created the
+// expected resources: CRDs (via waitForCRDs) and the operator Deployment.
+func verifyHelmRelease(ctx context.Context, t *testing.T, kubeConfigYAML []byte) {
+	t.Helper()
+
+	scheme := buildOperatorScheme()
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig(kubeConfigYAML)
+	if err != nil {
+		t.Fatalf("building REST config: %v", err)
+	}
+	c, err := client.New(restCfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("creating k8s client: %v", err)
+	}
+
+	// CRDs are installed from the chart's crds/ directory.
+	crdCtx, crdCancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer crdCancel()
+	if err := waitForCRDs(crdCtx, c); err != nil {
+		t.Fatalf("CRDs not established after helm install: %v", err)
+	}
+	t.Log("helm: CRDs established")
+
+	// The operator Deployment should exist (pod may not be running since the
+	// operator image is not loaded into k3s — that is expected).
+	var deployment appsv1.Deployment
+	deployCtx, deployCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer deployCancel()
+	if err := wait.PollUntilContextTimeout(deployCtx, pollInterval, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		err := c.Get(ctx, types.NamespacedName{
+			Name:      helmReleaseName,
+			Namespace: helmReleaseNS,
+		}, &deployment)
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return err == nil, err
+	}); err != nil {
+		t.Fatalf("Deployment %s/%s not found after helm install: %v", helmReleaseNS, helmReleaseName, err)
+	}
+	t.Logf("helm: Deployment %s/%s created (replicas=%d)", deployment.Namespace, deployment.Name, *deployment.Spec.Replicas)
+}

--- a/tests/integration/operator_test.go
+++ b/tests/integration/operator_test.go
@@ -68,8 +68,8 @@ func startSharedK3s(ctx context.Context) (*sharedK3sCluster, error) {
 
 	repoRoot := "../.."
 	for _, pair := range []struct{ src, dst string }{
-		{"deploy/helm/mcp-anything/crds/mcpproxy.yaml", "mcpproxy.yaml"},
-		{"deploy/helm/mcp-anything/crds/mcpupstream.yaml", "mcpupstream.yaml"},
+		{"charts/mcp-anything/crds/mcpproxy.yaml", "mcpproxy.yaml"},
+		{"charts/mcp-anything/crds/mcpupstream.yaml", "mcpupstream.yaml"},
 	} {
 		data, err := os.ReadFile(filepath.Join(repoRoot, pair.src))
 		if err != nil {


### PR DESCRIPTION
Implements #095: Helm chart release

- Move chart from `deploy/helm/mcp-anything/` to `charts/mcp-anything/` (chart-releaser-action convention)
- Fix `tests/integration/operator_test.go` CRD path references
- Add Makefile helm targets: `helm-lint`, `helm-package`, `helm-push`
- Add `helm_charts` to `.goreleaser.yml` for OCI publishing on release tags
- Add `.cr.yaml` chart-releaser configuration
- Add `tests/integration/helm_test.go`: installs chart from local OCI registry into k3s, verifies CRDs and Deployment

Note: GitHub Actions workflow changes for CI helm push must be added manually (see issue comment for snippets).

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Official Helm chart for mcp-anything with CRDs, operator Deployment, RBAC, ServiceAccount, helper templates and secure defaults (probes, security, resources).

* **Chores**
  * Added build/publish support for an operator binary and container images, Helm packaging/publishing workflows, Makefile targets, and CI jobs to build/push artifacts.

* **Tests**
  * Integration test that installs the Helm chart into an isolated cluster and verifies CRD readiness and operator Deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->