### PR TITLE
docs: add website docs section and update README with Kraken example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,38 @@ docker run -v $(pwd)/config.yaml:/etc/mcp-anything/config.yaml \
   ghcr.io/gaarutyunov/mcp-anything:latest
 ```
 
-### Minimal config
+### Connect to Kraken Market Data
+
+The Kraken cryptocurrency exchange exposes a public REST API — no API key required. A ready-to-use OpenAPI spec and overlay are included in [deploy/examples/kraken/](deploy/examples/kraken/).
 
 ```yaml
+# config.yaml
 upstreams:
-  - name: petstore
+  - name: kraken
     type: http
-    tool_prefix: pets
-    base_url: https://petstore.swagger.io/v2
+    tool_prefix: kraken
+    base_url: https://api.kraken.com
     openapi:
-      source: https://petstore.swagger.io/v2/swagger.json
+      source: deploy/examples/kraken/spec.yaml
+    overlay:
+      source: deploy/examples/kraken/overlay.yaml
 ```
 
-This exposes every operation in the Petstore API as an MCP tool. Connect any MCP client to `http://localhost:8080/mcp`.
+```bash
+proxy --config config.yaml
+```
+
+Connect any MCP client to `http://localhost:8080/mcp`. Five tools are now available:
+
+| Tool | Description |
+|------|-------------|
+| `kraken__get_system_status` | Exchange status and server time |
+| `kraken__get_ticker` | Real-time ask/bid/last price for any pair (e.g. `XBTUSD`) |
+| `kraken__get_ohlc` | OHLC candlestick data at any interval |
+| `kraken__get_order_book` | Live order book with top 5 bid/ask levels |
+| `kraken__get_recent_trades` | Most recent 10 public trades |
+
+The overlay in [deploy/examples/kraken/overlay.yaml](deploy/examples/kraken/overlay.yaml) applies jq transforms that flatten Kraken's nested response format into clean named fields — no client-side parsing required.
 
 ## Configuration
 
@@ -65,23 +84,18 @@ server:
     - sse
 
 upstreams:
-  - name: petstore
+  # HTTP upstream backed by an OpenAPI spec
+  - name: kraken
     type: http
-    tool_prefix: pets
-    base_url: https://api.petstore.io/v2
+    tool_prefix: kraken
+    base_url: https://api.kraken.com
     openapi:
-      source: /etc/mcp-anything/specs/petstore.yaml
+      source: deploy/examples/kraken/spec.yaml
       refresh_interval: 5m
     overlay:
-      source: /etc/mcp-anything/overlays/petstore.yaml
-    outbound_auth:
-      strategy: oauth2_client_credentials
-      oauth2_client_credentials:
-        token_url: https://idp.example.com/oauth/token
-        client_id: ${CLIENT_ID}
-        client_secret: ${CLIENT_SECRET}
-        scopes: [read:pets, write:pets]
+      source: deploy/examples/kraken/overlay.yaml
 
+  # Shell command upstream — wraps any CLI tool
   - name: cluster
     type: command
     tool_prefix: k8s
@@ -95,6 +109,7 @@ upstreams:
             required: true
         timeout: 30s
 
+  # JavaScript script upstream — custom logic in Sobek runtime
   - name: custom
     type: script
     tool_prefix: ops
@@ -107,53 +122,63 @@ upstreams:
             type: string
         timeout: 10s
 
+# Serve different tool sets at different endpoints
 groups:
   - name: all
     endpoint: /mcp
-    upstreams: [petstore, cluster, custom]
+    upstreams: [kraken, cluster, custom]
 
-  - name: readonly
-    endpoint: /mcp/readonly
-    upstreams: [petstore]
-    filter: "$.paths.*.get[?(@['x-mcp-safe'] == true)]"
+  - name: market
+    endpoint: /mcp/market
+    upstreams: [kraken]
+    filter: "$.paths[?(@['x-mcp-safe'] == true)]"
 ```
 
-See [deploy/example/](deploy/example/) for a complete example with auth, overlays, and groups.
+See [deploy/examples/](deploy/examples/) for complete examples including Kubernetes CRDs and Helm values.
 
 ## OpenAPI Overlays
 
-Customize how operations are exposed as MCP tools without modifying the original spec:
+Customize how operations are exposed as MCP tools without modifying the original spec. The [Kraken overlay](deploy/examples/kraken/overlay.yaml) shows realistic use:
 
 ```yaml
 overlay: 1.0.0
 info:
-  title: Petstore overlay
+  title: Kraken Market Data Overlay
   version: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+
 actions:
-  # Remove internal endpoints
-  - target: $.paths['/internal/metrics']
-    remove: true
-
-  # Disable an operation
-  - target: $.paths['/pets/{petId}'].delete
+  # Override tool name and flatten Kraken's nested result wrapper with jq
+  - target: "$.paths[\"/0/public/Ticker\"].get"
     update:
-      x-mcp-enabled: false
+      x-mcp-tool-name: get_ticker
+      description: >
+        Get current ticker information for a trading pair (e.g. XBTUSD, ETHUSD).
+        Returns ask, bid, last price, 24h volume, VWAP, high, low, and trade count.
+      x-mcp-response-transform: >
+        .result | to_entries[0] | {
+          pair: .key,
+          ask: .value.a[0],
+          bid: .value.b[0],
+          lastPrice: .value.c[0],
+          volume24h: .value.v[1],
+          vwap24h: .value.p[1],
+          high24h: .value.h[1],
+          low24h: .value.l[1],
+          trades24h: .value.t[1],
+          openingPrice: .value.o
+        }
 
-  # Skip auth for public endpoints
-  - target: $.paths['/health'].get
+  # Limit order book depth to top 5 levels
+  - target: "$.paths[\"/0/public/Depth\"].get"
     update:
-      x-mcp-auth-required: false
-
-  # Override tool name and mark as safe
-  - target: $.paths['/pets'].get
-    update:
-      x-mcp-tool-name: list_pets
-      x-mcp-safe: true
-
-  # Binary response format
-  - target: $.paths['/pets/{petId}/photo'].get
-    update:
-      x-mcp-response-format: image
+      x-mcp-tool-name: get_order_book
+      x-mcp-response-transform: >
+        .result | to_entries[0] | {
+          pair: .key,
+          asks: .value.asks[:5],
+          bids: .value.bids[:5]
+        }
 ```
 
 ### x-mcp extensions
@@ -177,7 +202,7 @@ actions:
 | Strategy | Description |
 |----------|-------------|
 | `jwt` | OIDC JWT validation with JWKS auto-rotation |
-| `introspection` | Token introspection via OIDC server |
+| `introspection` | Token introspection via OIDC discovery endpoint |
 | `apikey` | Static API key from a custom header |
 | `lua` | Custom validation logic in Lua |
 | `none` | No authentication |
@@ -186,10 +211,10 @@ actions:
 
 | Strategy | Description |
 |----------|-------------|
-| `bearer` | Static Bearer token from environment |
-| `oauth2_client_credentials` | OAuth2 CC flow with token caching |
+| `bearer` | Static Bearer token from environment variable |
+| `oauth2_client_credentials` | OAuth2 CC flow with automatic token caching and refresh |
 | `api_key` | API key header injection |
-| `lua` | Custom token acquisition in Lua |
+| `lua` | Custom token acquisition logic in Lua |
 
 Per-upstream overrides and per-operation bypass (`x-mcp-auth-required: false`) are supported.
 
@@ -201,13 +226,14 @@ MCP Client ──→ mcp-anything proxy ──→ HTTP API (OpenAPI)
                                   ──→ JavaScript script
 ```
 
-The proxy is a single stateless binary. On startup it loads the config, fetches OpenAPI specs, applies overlays, generates MCP tools, compiles jq transforms, and validates everything with dry-run. At runtime it handles MCP protocol, routes tool calls to the right upstream, manages auth, and validates requests/responses.
+The proxy is a single stateless binary. On startup it loads the config, fetches OpenAPI specs, applies overlays, generates MCP tools, compiles jq transforms, and validates everything with dry-run. At runtime it handles the MCP protocol, routes tool calls to the right upstream, manages auth, and validates requests and responses.
 
 Key design properties:
 - **Stateless** — no shared mutable state; each request is self-contained
 - **Atomic hot-reload** — config changes don't drop in-flight requests
 - **Overlay-as-configuration** — all per-operation behavior via OpenAPI Overlay extensions
 - **Uniform pipeline** — auto-generated and manual tools use identical code paths
+- **Double-underscore namespacing** — tool names follow `{prefix}__{operation}` convention
 
 ## Deployment
 
@@ -221,7 +247,7 @@ docker run -p 8080:8080 \
 
 ### Kubernetes
 
-The proxy is designed for Kubernetes. Mount config as a ConfigMap, specs and overlays as separate ConfigMaps for independent update cycles:
+The proxy is designed for Kubernetes. Mount config, specs, and overlays as separate ConfigMaps for independent update cycles:
 
 ```yaml
 apiVersion: apps/v1
@@ -245,6 +271,8 @@ spec:
           configMap:
             name: mcp-anything-config
 ```
+
+Use the `MCPProxy` and `MCPUpstream` CRDs with the included Helm chart for production deployments. See [deploy/examples/kraken/](deploy/examples/kraken/) for a complete Kubernetes example including CRD manifests and Helm values.
 
 ## Development
 

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -1,0 +1,396 @@
+---
+import '../styles/global.css';
+
+interface Props {
+  title: string;
+  description: string;
+  current: string;
+}
+
+const { title, description, current } = Astro.props;
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+
+const nav = [
+  {
+    group: 'Getting Started',
+    items: [
+      { slug: '', label: 'Introduction' },
+    ],
+  },
+  {
+    group: 'Providers',
+    items: [
+      { slug: 'openapi', label: 'HTTP APIs (OpenAPI)' },
+      { slug: 'commands', label: 'Shell Commands' },
+      { slug: 'scripts', label: 'JavaScript Scripts' },
+    ],
+  },
+  {
+    group: 'Configuration',
+    items: [
+      { slug: 'routing', label: 'Multi-Upstream Routing' },
+      { slug: 'overlays', label: 'OpenAPI Overlays' },
+      { slug: 'groups', label: 'Tool Groups' },
+      { slug: 'config', label: 'Config Reference' },
+    ],
+  },
+  {
+    group: 'Authentication',
+    items: [
+      { slug: 'auth', label: 'Inbound & Outbound Auth' },
+      { slug: 'oauth2-sessions', label: 'Per-User OAuth2 Sessions' },
+    ],
+  },
+  {
+    group: 'Operations',
+    items: [
+      { slug: 'hot-reload', label: 'Hot-Reload & Spec Refresh' },
+      { slug: 'telemetry', label: 'OpenTelemetry' },
+      { slug: 'rate-limiting', label: 'Rate Limiting' },
+      { slug: 'circuit-breaking', label: 'Circuit Breaking' },
+      { slug: 'caching', label: 'Tool Result Caching' },
+      { slug: 'token-counting', label: 'Token Counting' },
+    ],
+  },
+  {
+    group: 'Discovery',
+    items: [
+      { slug: 'search', label: 'Semantic Tool Search' },
+      { slug: 'ui', label: 'MCP Apps' },
+    ],
+  },
+  {
+    group: 'Deployment',
+    items: [
+      { slug: 'kubernetes', label: 'Kubernetes & Helm' },
+      { slug: 'transport', label: 'Gateway Transport' },
+      { slug: 'caddy', label: 'Caddy Module' },
+    ],
+  },
+  {
+    group: 'Extending',
+    items: [
+      { slug: 'sdk', label: 'Go SDK' },
+    ],
+  },
+];
+
+function href(slug: string) {
+  return slug === '' ? '/docs' : `/docs/${slug}`;
+}
+
+function isActive(slug: string) {
+  return slug === current;
+}
+---
+
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="canonical" href={canonicalURL} />
+    <meta name="description" content={description} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:site_name" content="mcp-anything" />
+    <meta name="generator" content={Astro.generator} />
+    <title>{title} — mcp-anything</title>
+    <!-- Prevent FOUC -->
+    <script is:inline>
+      (function() {
+        const saved = localStorage.getItem('theme');
+        if (saved === 'dark' || (!saved && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
+  </head>
+  <body class="bg-white text-neutral-900 antialiased font-sans dark:bg-neutral-950 dark:text-neutral-100">
+
+    <!-- Top Nav -->
+    <nav class="sticky top-0 z-50 w-full border-b border-neutral-200 bg-white/80 backdrop-blur-sm dark:border-neutral-800 dark:bg-neutral-950/80">
+      <div class="flex h-14 items-center justify-between px-6">
+        <div class="flex items-center gap-6">
+          <!-- Mobile sidebar toggle -->
+          <button
+            id="sidebar-toggle"
+            type="button"
+            class="flex h-8 w-8 items-center justify-center rounded-md text-neutral-500 transition hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100 lg:hidden"
+            aria-label="Toggle sidebar"
+          >
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/></svg>
+          </button>
+          <a href="/" class="flex items-center gap-2 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+            <svg class="h-5 w-5" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect width="180" height="180" rx="24" class="fill-neutral-900 dark:fill-neutral-100"/>
+              <mask id="doc-nav-m" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="7" y="7" width="166" height="166"><path d="M173 7H7V173H173V7Z" fill="white"/></mask>
+              <g mask="url(#doc-nav-m)">
+                <path d="M23.6 85.25L86.2 22.65C94.85 14.01 108.86 14.01 117.5 22.65C126.15 31.29 126.15 45.31 117.5 53.95L70.23 101.23" class="stroke-white dark:stroke-neutral-900" stroke-width="11.07" stroke-linecap="round"/>
+                <path d="M70.88 100.58L117.5 53.95C126.15 45.31 140.16 45.31 148.81 53.95L149.13 54.28C157.78 62.92 157.78 76.94 149.13 85.58L92.51 142.2C89.63 145.08 89.63 149.75 92.51 152.63L104.14 164.26" class="stroke-white dark:stroke-neutral-900" stroke-width="11.07" stroke-linecap="round"/>
+                <path d="M101.85 38.3L55.55 84.6C46.91 93.24 46.91 107.26 55.55 115.9C64.2 124.55 78.21 124.55 86.85 115.9L133.15 69.6" class="stroke-white dark:stroke-neutral-900" stroke-width="11.07" stroke-linecap="round"/>
+              </g>
+              <g transform="translate(140, 140)" class="stroke-white dark:stroke-neutral-900" stroke-width="7" stroke-linecap="round">
+                <line x1="0" y1="-14" x2="0" y2="14"/><line x1="-12.12" y1="-7" x2="12.12" y2="7"/><line x1="-12.12" y1="7" x2="12.12" y2="-7"/>
+              </g>
+            </svg>
+            mcp-anything
+          </a>
+          <span class="hidden text-neutral-300 dark:text-neutral-600 sm:block">/</span>
+          <span class="hidden text-sm text-neutral-500 dark:text-neutral-400 sm:block">Docs</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <a
+            href="https://github.com/gaarutyunov/mcp-anything"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex items-center gap-1.5 text-sm text-neutral-500 transition hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+          >
+            <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+            GitHub
+          </a>
+          <button
+            id="theme-toggle"
+            type="button"
+            class="flex h-8 w-8 items-center justify-center rounded-md text-neutral-500 transition hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
+            aria-label="Toggle theme"
+          >
+            <svg class="hidden h-4 w-4 dark:block" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"/></svg>
+            <svg class="block h-4 w-4 dark:hidden" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/></svg>
+          </button>
+        </div>
+      </div>
+    </nav>
+
+    <div class="flex">
+      <!-- Sidebar overlay (mobile) -->
+      <div id="sidebar-overlay" class="fixed inset-0 z-40 bg-black/30 hidden lg:hidden" aria-hidden="true"></div>
+
+      <!-- Sidebar -->
+      <aside
+        id="sidebar"
+        class="fixed top-14 bottom-0 left-0 z-40 w-64 translate-x-[-100%] overflow-y-auto border-r border-neutral-200 bg-white px-4 py-6 transition-transform duration-200 dark:border-neutral-800 dark:bg-neutral-950 lg:sticky lg:h-[calc(100vh-3.5rem)] lg:translate-x-0"
+      >
+        {nav.map((group) => (
+          <div class="mb-6">
+            <p class="mb-1.5 px-2 text-xs font-semibold uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
+              {group.group}
+            </p>
+            {group.items.map((item) => (
+              <a
+                href={href(item.slug)}
+                class:list={[
+                  'flex items-center rounded-md px-2 py-1.5 text-sm transition',
+                  isActive(item.slug)
+                    ? 'bg-neutral-100 font-medium text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100'
+                    : 'text-neutral-600 hover:bg-neutral-50 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-900 dark:hover:text-neutral-100',
+                ]}
+              >
+                {item.label}
+              </a>
+            ))}
+          </div>
+        ))}
+      </aside>
+
+      <!-- Main content -->
+      <main class="min-w-0 flex-1 px-6 py-10 lg:px-10 lg:py-12">
+        <article class="mx-auto max-w-2xl">
+          <slot />
+        </article>
+      </main>
+    </div>
+
+    <script>
+      // Theme toggle
+      document.getElementById('theme-toggle')?.addEventListener('click', () => {
+        const isDark = document.documentElement.classList.toggle('dark');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+
+      // Mobile sidebar
+      const sidebar = document.getElementById('sidebar');
+      const overlay = document.getElementById('sidebar-overlay');
+      const sidebarToggle = document.getElementById('sidebar-toggle');
+
+      function openSidebar() {
+        sidebar?.classList.remove('translate-x-[-100%]');
+        overlay?.classList.remove('hidden');
+        document.body.style.overflow = 'hidden';
+      }
+
+      function closeSidebar() {
+        sidebar?.classList.add('translate-x-[-100%]');
+        overlay?.classList.add('hidden');
+        document.body.style.overflow = '';
+      }
+
+      sidebarToggle?.addEventListener('click', openSidebar);
+      overlay?.addEventListener('click', closeSidebar);
+    </script>
+  </body>
+</html>
+
+<style>
+  /* Prose styles for docs content */
+  article :global(h1) {
+    font-size: 1.875rem;
+    font-weight: 700;
+    letter-spacing: -0.025em;
+    color: var(--color-neutral-900, #171717);
+    margin-bottom: 0.75rem;
+    line-height: 1.2;
+  }
+  article :global(h2) {
+    font-size: 1.25rem;
+    font-weight: 600;
+    letter-spacing: -0.015em;
+    color: var(--color-neutral-900, #171717);
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid #e5e5e5;
+  }
+  article :global(h3) {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-neutral-900, #171717);
+    margin-top: 1.75rem;
+    margin-bottom: 0.5rem;
+  }
+  article :global(p) {
+    font-size: 0.9375rem;
+    line-height: 1.7;
+    color: #525252;
+    margin-bottom: 1rem;
+  }
+  article :global(ul), article :global(ol) {
+    margin-bottom: 1rem;
+    padding-left: 1.5rem;
+  }
+  article :global(li) {
+    font-size: 0.9375rem;
+    line-height: 1.7;
+    color: #525252;
+    margin-bottom: 0.25rem;
+  }
+  article :global(li > ul), article :global(li > ol) {
+    margin-top: 0.25rem;
+    margin-bottom: 0.25rem;
+  }
+  article :global(code):not(pre code) {
+    font-family: ui-monospace, 'Cascadia Code', monospace;
+    font-size: 0.8125rem;
+    background: #f5f5f5;
+    color: #171717;
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    border: 1px solid #e5e5e5;
+  }
+  article :global(pre) {
+    background: #fafafa;
+    border: 1px solid #e5e5e5;
+    border-radius: 0.5rem;
+    padding: 1rem 1.25rem;
+    overflow-x: auto;
+    margin-bottom: 1.25rem;
+    font-family: ui-monospace, 'Cascadia Code', monospace;
+    font-size: 0.8125rem;
+    line-height: 1.6;
+    color: #404040;
+  }
+  article :global(pre code) {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: inherit;
+    color: inherit;
+  }
+  article :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+    margin-bottom: 1.25rem;
+  }
+  article :global(th) {
+    text-align: left;
+    font-weight: 600;
+    color: #171717;
+    border-bottom: 1px solid #e5e5e5;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.8125rem;
+  }
+  article :global(td) {
+    color: #525252;
+    border-bottom: 1px solid #f5f5f5;
+    padding: 0.5rem 0.75rem;
+    vertical-align: top;
+  }
+  article :global(a) {
+    color: #171717;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  article :global(a:hover) {
+    color: #000;
+  }
+  article :global(blockquote) {
+    border-left: 3px solid #e5e5e5;
+    padding-left: 1rem;
+    margin-left: 0;
+    margin-bottom: 1rem;
+    color: #737373;
+    font-size: 0.9375rem;
+  }
+  article :global(.lead) {
+    font-size: 1.0625rem;
+    color: #737373;
+    margin-bottom: 2rem;
+    line-height: 1.6;
+  }
+
+  /* Dark mode */
+  .dark article :global(h1),
+  .dark article :global(h2),
+  .dark article :global(h3) {
+    color: #f5f5f5;
+  }
+  .dark article :global(h2) {
+    border-bottom-color: #262626;
+  }
+  .dark article :global(p),
+  .dark article :global(li) {
+    color: #a3a3a3;
+  }
+  .dark article :global(code):not(pre code) {
+    background: #1a1a1a;
+    color: #e5e5e5;
+    border-color: #262626;
+  }
+  .dark article :global(pre) {
+    background: #0f0f0f;
+    border-color: #262626;
+    color: #d4d4d4;
+  }
+  .dark article :global(th) {
+    color: #e5e5e5;
+    border-bottom-color: #262626;
+  }
+  .dark article :global(td) {
+    color: #a3a3a3;
+    border-bottom-color: #1a1a1a;
+  }
+  .dark article :global(a) {
+    color: #e5e5e5;
+  }
+  .dark article :global(blockquote) {
+    border-left-color: #404040;
+    color: #737373;
+  }
+  .dark article :global(.lead) {
+    color: #737373;
+  }
+</style>

--- a/website/src/pages/docs/auth.astro
+++ b/website/src/pages/docs/auth.astro
@@ -1,0 +1,159 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Authentication"
+  description="Inbound auth (MCP clients → proxy) and outbound auth (proxy → upstream APIs). JWT, OAuth2, API key, introspection, Lua, and JavaScript."
+  current="auth"
+>
+  <h1>Authentication</h1>
+  <p class="lead">The proxy handles two independent auth directions: <strong>inbound</strong> — validating tokens from MCP clients — and <strong>outbound</strong> — attaching credentials to upstream API requests.</p>
+
+  <h2>Inbound auth</h2>
+  <p>Inbound auth protects your MCP endpoint. Configure it per-group:</p>
+  <pre><code>groups:
+  - name: default
+    endpoint: /mcp
+    upstreams: [kraken]
+    inbound_auth:
+      strategy: jwt
+      jwt:
+        issuer: https://auth.example.com
+        jwks_url: https://auth.example.com/.well-known/jwks.json
+        audience: mcp-anything</code></pre>
+
+  <h3>JWT</h3>
+  <p>Validates OIDC JWTs. JWKS keys are auto-rotated on expiry.</p>
+  <pre><code>inbound_auth:
+  strategy: jwt
+  jwt:
+    issuer: https://auth.example.com
+    jwks_url: https://auth.example.com/.well-known/jwks.json
+    audience: my-mcp-proxy          # optional, validates aud claim
+    algorithms: [RS256, ES256]      # optional, defaults to RS256</code></pre>
+
+  <h3>Token introspection</h3>
+  <p>Validates tokens via an OIDC introspection endpoint. Suitable for opaque tokens.</p>
+  <pre><code>inbound_auth:
+  strategy: introspection
+  introspection:
+    endpoint: https://auth.example.com/oauth/introspect
+    client_id: $&#123;INTROSPECTION_CLIENT_ID&#125;
+    client_secret: $&#123;INTROSPECTION_CLIENT_SECRET&#125;</code></pre>
+
+  <h3>API key</h3>
+  <p>Validates a static key from a request header.</p>
+  <pre><code>inbound_auth:
+  strategy: apikey
+  apikey:
+    header: X-API-Key
+    value: $&#123;API_KEY&#125;</code></pre>
+
+  <h3>Lua</h3>
+  <p>Custom validation logic in a Lua script. Receives the request headers and must return a boolean.</p>
+  <pre><code>inbound_auth:
+  strategy: lua
+  lua:
+    source: scripts/validate_token.lua</code></pre>
+  <pre><code>-- scripts/validate_token.lua
+local token = headers["Authorization"]
+if not token then return false end
+-- custom validation logic
+return token:sub(1, 7) == "Bearer " and #token > 20</code></pre>
+
+  <h3>JavaScript (Sobek)</h3>
+  <p>Custom validation logic in a sandboxed ECMAScript runtime (Grafana Sobek). Receives the request headers as a plain object and must return a boolean.</p>
+  <pre><code>inbound_auth:
+  strategy: js
+  js:
+    source: scripts/validate_token.js</code></pre>
+  <pre><code>// scripts/validate_token.js
+const token = headers["Authorization"] ?? "";
+if (!token.startsWith("Bearer ")) return false;
+// custom HMAC or structural check
+return token.length > 20;</code></pre>
+
+  <h3>None</h3>
+  <pre><code>inbound_auth:
+  strategy: none</code></pre>
+  <p>No authentication. Use this for development or for public endpoints.</p>
+
+  <h2>Outbound auth</h2>
+  <p>Outbound auth injects credentials into requests the proxy makes to upstream APIs. Configure it per-upstream:</p>
+  <pre><code>upstreams:
+  - name: myapi
+    type: http
+    tool_prefix: api
+    base_url: https://api.example.com
+    openapi:
+      source: https://api.example.com/openapi.yaml
+    outbound_auth:
+      strategy: oauth2_client_credentials
+      oauth2_client_credentials:
+        token_url: https://auth.example.com/oauth/token
+        client_id: $&#123;CLIENT_ID&#125;
+        client_secret: $&#123;CLIENT_SECRET&#125;
+        scopes: [read:data, write:data]</code></pre>
+
+  <h3>Bearer token</h3>
+  <p>Injects a static Bearer token from an environment variable.</p>
+  <pre><code>outbound_auth:
+  strategy: bearer
+  bearer:
+    token: $&#123;API_TOKEN&#125;</code></pre>
+
+  <h3>OAuth2 Client Credentials</h3>
+  <p>Performs the OAuth2 CC flow and caches the token until it expires, then refreshes automatically.</p>
+  <pre><code>outbound_auth:
+  strategy: oauth2_client_credentials
+  oauth2_client_credentials:
+    token_url: https://auth.example.com/oauth/token
+    client_id: $&#123;CLIENT_ID&#125;
+    client_secret: $&#123;CLIENT_SECRET&#125;
+    scopes: [read, write]</code></pre>
+
+  <h3>API key</h3>
+  <p>Injects an API key as a header or query parameter.</p>
+  <pre><code>outbound_auth:
+  strategy: api_key
+  api_key:
+    header: X-API-Key        # or use: query: api_key
+    value: $&#123;UPSTREAM_KEY&#125;</code></pre>
+
+  <h3>Lua</h3>
+  <p>Custom token acquisition — useful for non-standard auth schemes.</p>
+  <pre><code>outbound_auth:
+  strategy: lua
+  lua:
+    source: scripts/get_token.lua</code></pre>
+
+  <h3>JavaScript (Sobek)</h3>
+  <p>Token acquisition in a sandboxed ECMAScript runtime. The script must return a string that is used as the <code>Authorization</code> header value.</p>
+  <pre><code>outbound_auth:
+  strategy: js
+  js:
+    source: scripts/get_token.js</code></pre>
+  <pre><code>// scripts/get_token.js
+const resp = ctx.fetch("https://auth.example.com/token", &#123;
+  method: "POST",
+  body: JSON.stringify(&#123; client_id: ctx.env.CLIENT_ID, client_secret: ctx.env.CLIENT_SECRET &#125;),
+  headers: &#123; "Content-Type": "application/json" &#125;,
+&#125;);
+return "Bearer " + resp.json().access_token;</code></pre>
+
+  <h2>Per-operation bypass</h2>
+  <p>Set <code>x-mcp-auth-required: false</code> on an operation via an overlay to skip outbound auth for that operation. Useful for public endpoints within an otherwise authenticated upstream.</p>
+  <pre><code>- target: "$.paths[\"/public/status\"].get"
+  update:
+    x-mcp-auth-required: false</code></pre>
+
+  <h2>Secret references</h2>
+  <p>All config fields that reference secrets use <code>$&#123;ENV_VAR&#125;</code> syntax. The proxy expands these at startup from the process environment. Secret values are never logged.</p>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/groups">Tool Groups</a> — per-group inbound auth configuration</li>
+    <li><a href="/docs/overlays">OpenAPI Overlays</a> — per-operation auth bypass</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/caching.astro
+++ b/website/src/pages/docs/caching.astro
@@ -1,0 +1,59 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Tool Result Caching"
+  description="Cache MCP tool responses with configurable TTL, per-user isolation, and automatic invalidation on spec refresh."
+  current="caching"
+>
+  <h1>Tool Result Caching</h1>
+  <p class="lead">Tool result caching stores upstream responses in memory and serves them directly for repeat calls within the TTL window — reducing latency and upstream API load for read-heavy tool sets.</p>
+
+  <h2>Configuration</h2>
+  <p>Caching is configured per-upstream. All tools in the upstream share the cache store unless overridden per-tool via an overlay.</p>
+  <pre><code>upstreams:
+  - name: myapi
+    type: http
+    tool_prefix: api
+    base_url: https://api.example.com
+    openapi:
+      source: spec.yaml
+    cache:
+      enabled: true
+      ttl: 60s          # how long to keep a cached result
+      per_user: false   # if true, cache is keyed per authenticated user
+      max_size: 1000    # maximum number of entries (LRU eviction)</code></pre>
+
+  <h2>Per-tool TTL override</h2>
+  <p>Override TTL for individual operations using the <code>x-mcp-cache-ttl</code> extension in an overlay:</p>
+  <pre><code># overlay.yaml
+- target: "$.paths[\"/ticker\"].get"
+  update:
+    x-mcp-cache-ttl: 5s       # high-frequency data: cache only briefly
+
+- target: "$.paths[\"/instruments\"].get"
+  update:
+    x-mcp-cache-ttl: 1h       # slow-changing reference data: cache longer</code></pre>
+
+  <h2>Disabling cache for a tool</h2>
+  <pre><code>- target: "$.paths[\"/account/balance\"].get"
+  update:
+    x-mcp-cache-ttl: 0        # 0 disables caching for this operation</code></pre>
+
+  <h2>Per-user caching</h2>
+  <p>When <code>per_user: true</code> the cache key includes the authenticated user's identity (JWT <code>sub</code> claim or API key identity). Users never see each other's cached data. This requires inbound auth to be configured. See <a href="/docs/auth">Authentication</a>.</p>
+
+  <h2>Cache invalidation</h2>
+  <p>Entries expire after their TTL. The entire cache for an upstream is flushed whenever the upstream's OpenAPI spec is refreshed (background spec refresh) or when the proxy hot-reloads its config.</p>
+
+  <h2>Metrics</h2>
+  <p>Cache hits and misses are tracked under <code>mcp.cache.hits</code> and <code>mcp.cache.misses</code> OpenTelemetry counters, labelled by tool name. See <a href="/docs/telemetry">OpenTelemetry</a>.</p>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/overlays">OpenAPI Overlays</a> — per-operation cache TTL</li>
+    <li><a href="/docs/hot-reload">Hot-Reload &amp; Spec Refresh</a> — triggers cache invalidation</li>
+    <li><a href="/docs/token-counting">Token Counting</a> — monitor response sizes</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/caddy.astro
+++ b/website/src/pages/docs/caddy.astro
@@ -1,0 +1,64 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Caddy Module"
+  description="Embed mcp-anything as a native Caddy HTTP handler using the xcaddy build system. No separate proxy process required."
+  current="caddy"
+>
+  <h1>Caddy Module</h1>
+  <p class="lead">The Caddy module lets you run mcp-anything as a native Caddy directive — no standalone proxy binary, no separate sidecar. Caddy handles TLS, routing, and access logging; mcp-anything handles MCP tool generation.</p>
+
+  <h2>Build a Caddy binary with the module</h2>
+  <p>Use <a href="https://github.com/caddyserver/xcaddy" target="_blank" rel="noopener noreferrer">xcaddy</a> to compile a custom Caddy binary that includes the mcp-anything handler:</p>
+  <pre><code>xcaddy build \
+  --with github.com/gaarutyunov/mcp-anything/caddy</code></pre>
+  <p>Or use the pre-built Docker image that ships with the module already embedded:</p>
+  <pre><code>docker pull ghcr.io/gaarutyunov/mcp-anything-caddy:latest</code></pre>
+
+  <h2>Caddyfile configuration</h2>
+  <pre><code>:443 &#123;
+  tls /etc/tls/cert.pem /etc/tls/key.pem
+
+  route /mcp* &#123;
+    mcp_anything &#123;
+      config /etc/mcp-anything/config.yaml
+    &#125;
+  &#125;
+
+  # All other routes handled by Caddy as normal
+  reverse_proxy /api/* backend:8080
+&#125;</code></pre>
+
+  <h2>JSON config (Caddy API)</h2>
+  <p>If you manage Caddy via its admin API, the handler can be configured in JSON:</p>
+  <pre><code>&#123;
+  "handler": "mcp_anything",
+  "config": "/etc/mcp-anything/config.yaml"
+&#125;</code></pre>
+
+  <h2>Hot-reload</h2>
+  <p>The mcp-anything config inside Caddy supports the same fsnotify-based hot-reload as the standalone binary. A <code>caddy reload</code> also triggers a full config reload.</p>
+
+  <h2>TLS</h2>
+  <p>Caddy manages TLS automatically (ACME/Let's Encrypt). The mcp-anything module does not need separate TLS configuration — it inherits Caddy's listener. The <a href="/docs/transport">Gateway Transport</a> TLS settings still apply to outbound connections from the proxy to upstream APIs.</p>
+
+  <h2>Differences from the standalone binary</h2>
+  <table>
+    <thead><tr><th>Feature</th><th>Standalone binary</th><th>Caddy module</th></tr></thead>
+    <tbody>
+      <tr><td>TLS termination</td><td>Manual or via a reverse proxy</td><td>Automatic (ACME)</td></tr>
+      <tr><td>Multiple MCP endpoints</td><td><code>groups[].endpoint</code></td><td><code>route</code> blocks in Caddyfile</td></tr>
+      <tr><td>Access logs</td><td><code>log/slog</code> structured JSON</td><td>Caddy access log format</td></tr>
+      <tr><td>Process management</td><td>systemd / Docker</td><td>Caddy's own process</td></tr>
+    </tbody>
+  </table>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/transport">Gateway Transport</a> — outbound TLS and connection pooling</li>
+    <li><a href="/docs/hot-reload">Hot-Reload</a> — config reloading inside the module</li>
+    <li><a href="/docs/sdk">Go SDK</a> — embedding the proxy in other Go HTTP servers</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/circuit-breaking.astro
+++ b/website/src/pages/docs/circuit-breaking.astro
@@ -1,0 +1,61 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Circuit Breaking"
+  description="Per-upstream circuit breaker that prevents cascading failures when an upstream API becomes unavailable."
+  current="circuit-breaking"
+>
+  <h1>Circuit Breaking</h1>
+  <p class="lead">The proxy wraps each upstream in a circuit breaker. When an upstream starts failing consistently, the breaker opens and subsequent calls fail fast — protecting the upstream from being hammered and the MCP client from waiting on timeouts.</p>
+
+  <h2>How it works</h2>
+  <p>The circuit breaker has three states:</p>
+  <ul>
+    <li><strong>Closed</strong> — requests flow normally. Failures are counted in a rolling window.</li>
+    <li><strong>Open</strong> — requests fail immediately without reaching the upstream. After the <code>timeout</code> the breaker moves to half-open.</li>
+    <li><strong>Half-open</strong> — a probe request is sent. Success closes the breaker; failure reopens it.</li>
+  </ul>
+
+  <h2>Configuration</h2>
+  <pre><code>upstreams:
+  - name: myapi
+    type: http
+    tool_prefix: api
+    base_url: https://api.example.com
+    openapi:
+      source: spec.yaml
+    circuit_breaker:
+      threshold: 5          # failures before opening (within the window)
+      window: 30s           # rolling window size
+      timeout: 10s          # how long to stay open before probing
+      success_threshold: 2  # consecutive successes needed to close from half-open</code></pre>
+
+  <h2>Configuration fields</h2>
+  <table>
+    <thead><tr><th>Field</th><th>Default</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>threshold</code></td><td><code>5</code></td><td>Number of failures in <code>window</code> that trip the breaker</td></tr>
+      <tr><td><code>window</code></td><td><code>60s</code></td><td>Rolling time window for counting failures</td></tr>
+      <tr><td><code>timeout</code></td><td><code>30s</code></td><td>How long the breaker stays open before allowing a probe</td></tr>
+      <tr><td><code>success_threshold</code></td><td><code>1</code></td><td>Consecutive successes in half-open state before closing</td></tr>
+    </tbody>
+  </table>
+
+  <h2>What counts as a failure</h2>
+  <p>By default, any HTTP 5xx response or a connection error increments the failure counter. HTTP 4xx responses are not counted — they indicate a client error, not an upstream outage.</p>
+
+  <h2>MCP error when open</h2>
+  <p>When the breaker is open, tool calls return an MCP error with code <code>-32030</code> (upstream unavailable). The error message includes the upstream name and an estimate of when the next probe will fire.</p>
+
+  <h2>Metrics</h2>
+  <p>State transitions are emitted as OpenTelemetry events on the active trace span and as counters under <code>mcp.circuit_breaker.*</code>. The <code>mcp.circuit_breaker.state</code> gauge tracks the current state (0 = closed, 1 = half-open, 2 = open) per upstream. See <a href="/docs/telemetry">OpenTelemetry</a>.</p>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/rate-limiting">Rate Limiting</a> — throttle individual tools</li>
+    <li><a href="/docs/transport">Gateway Transport</a> — connection pooling and TLS settings</li>
+    <li><a href="/docs/telemetry">OpenTelemetry</a> — metrics and traces</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/commands.astro
+++ b/website/src/pages/docs/commands.astro
@@ -1,0 +1,134 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Shell Commands"
+  description="Expose kubectl, aws, gh, or any CLI tool as MCP tools with typed arguments and shell-escape security."
+  current="commands"
+>
+  <h1>Shell Commands</h1>
+  <p class="lead">Wrap any CLI tool as an MCP tool. Arguments are declared with types and passed into a command template. Shell-escape is applied automatically to prevent injection.</p>
+
+  <h2>Configuration</h2>
+  <pre><code>upstreams:
+  - name: cluster
+    type: command
+    tool_prefix: k8s
+    tools:
+      - name: get_pods
+        description: List pods in a namespace
+        command: kubectl get pods -n &#123;&#123;namespace&#125;&#125; -o json
+        args:
+          namespace:
+            type: string
+            description: Kubernetes namespace
+            required: true
+        timeout: 30s
+
+      - name: describe_pod
+        description: Describe a specific pod
+        command: kubectl describe pod &#123;&#123;pod&#125;&#125; -n &#123;&#123;namespace&#125;&#125;
+        args:
+          pod:
+            type: string
+            description: Pod name
+            required: true
+          namespace:
+            type: string
+            description: Kubernetes namespace
+            default: default
+        timeout: 20s</code></pre>
+
+  <h2>Argument interpolation</h2>
+  <p>Arguments are referenced in the <code>command</code> string using double-brace syntax: <code>&#123;&#123;arg_name&#125;&#125;</code>. Before execution, each argument value is shell-escaped to prevent injection attacks.</p>
+  <p>Supported argument types:</p>
+  <table>
+    <thead><tr><th>Type</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>string</code></td><td>Text value, shell-escaped</td></tr>
+      <tr><td><code>integer</code></td><td>Integer, validated before interpolation</td></tr>
+      <tr><td><code>number</code></td><td>Float, validated before interpolation</td></tr>
+      <tr><td><code>boolean</code></td><td>true/false</td></tr>
+      <tr><td><code>array</code></td><td>Comma-separated values</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Argument options</h2>
+  <table>
+    <thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>type</code></td><td>string</td><td>Argument type (see above)</td></tr>
+      <tr><td><code>description</code></td><td>string</td><td>Shown to the MCP client</td></tr>
+      <tr><td><code>required</code></td><td>bool</td><td>Whether the argument must be provided</td></tr>
+      <tr><td><code>default</code></td><td>any</td><td>Value used when argument is absent</td></tr>
+      <tr><td><code>enum</code></td><td>array</td><td>Allowed values</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Timeout</h2>
+  <p>The <code>timeout</code> field (e.g. <code>30s</code>, <code>2m</code>) sets the maximum execution time. Commands that exceed the timeout are killed and an error is returned to the MCP client.</p>
+
+  <h2>Working directory and environment</h2>
+  <p>Commands inherit the proxy process's working directory and environment. Use <code>$&#123;ENV_VAR&#125;</code> syntax in the command string to inject environment variables — these are expanded from the proxy environment before execution, not passed as shell variables.</p>
+  <pre><code>tools:
+  - name: aws_s3_ls
+    description: List S3 bucket contents
+    command: aws s3 ls s3://&#123;&#123;bucket&#125;&#125; --region $&#123;AWS_DEFAULT_REGION&#125;
+    args:
+      bucket:
+        type: string
+        required: true</code></pre>
+
+  <h2>Common examples</h2>
+
+  <h3>kubectl</h3>
+  <pre><code>tools:
+  - name: get_pods
+    command: kubectl get pods -n &#123;&#123;namespace&#125;&#125; -o json
+    args:
+      namespace:
+        type: string
+        required: true
+
+  - name: get_logs
+    command: kubectl logs &#123;&#123;pod&#125;&#125; -n &#123;&#123;namespace&#125;&#125; --tail &#123;&#123;lines&#125;&#125;
+    args:
+      pod:
+        type: string
+        required: true
+      namespace:
+        type: string
+        default: default
+      lines:
+        type: integer
+        default: 50</code></pre>
+
+  <h3>AWS CLI</h3>
+  <pre><code>tools:
+  - name: describe_instances
+    command: aws ec2 describe-instances --region &#123;&#123;region&#125;&#125; --output json
+    args:
+      region:
+        type: string
+        required: true
+        enum: [us-east-1, us-west-2, eu-west-1]</code></pre>
+
+  <h3>Git</h3>
+  <pre><code>tools:
+  - name: git_log
+    command: git -C &#123;&#123;repo&#125;&#125; log --oneline -&#123;&#123;count&#125;&#125;
+    args:
+      repo:
+        type: string
+        required: true
+      count:
+        type: integer
+        default: 20</code></pre>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/scripts">JavaScript Scripts</a> — for more complex logic requiring HTTP calls or conditional behavior</li>
+    <li><a href="/docs/routing">Multi-Upstream Routing</a> — combine command and HTTP upstreams in one proxy</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/config.astro
+++ b/website/src/pages/docs/config.astro
@@ -1,0 +1,244 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Configuration Reference"
+  description="Complete reference for all mcp-anything configuration fields. Single YAML file with environment variable expansion."
+  current="config"
+>
+  <h1>Configuration Reference</h1>
+  <p class="lead">A single YAML file defines everything. Environment variables are expanded with <code>$&#123;VAR&#125;</code> syntax. All secret fields must use this syntax — values are never logged.</p>
+
+  <h2>Top-level structure</h2>
+  <pre><code>server: ...
+upstreams: [...]
+groups: [...]
+telemetry: ...</code></pre>
+
+  <h2>server</h2>
+  <pre><code>server:
+  port: 8080                  # MCP server port (default: 8080)
+  host: 0.0.0.0               # bind address (default: 0.0.0.0)
+  read_timeout: 30s           # HTTP read timeout
+  write_timeout: 60s          # HTTP write timeout
+  idle_timeout: 120s          # keep-alive idle timeout
+  transport:                  # enabled MCP transports
+    - streamable-http         # default
+    - sse</code></pre>
+
+  <h2>upstreams[]</h2>
+
+  <h3>Common fields (all types)</h3>
+  <pre><code>- name: myapi           # unique identifier
+  type: http            # http | command | script
+  tool_prefix: api      # prefix for tool names → api__tool_name
+  description: ""       # optional upstream description</code></pre>
+
+  <h3>type: http</h3>
+  <pre><code>  base_url: https://api.example.com
+  openapi:
+    source: /path/to/spec.yaml    # file path or https:// URL
+    refresh_interval: 5m          # optional; omit to disable refresh
+  overlay:
+    source: /path/to/overlay.yaml # optional; file path or https:// URL
+  outbound_auth: ...              # see Authentication
+  transport: ...                  # see Gateway Transport</code></pre>
+
+  <h3>type: command</h3>
+  <pre><code>  tools:
+    - name: my_tool
+      description: What this tool does
+      command: mybin --flag &#123;&#123;arg&#125;&#125;
+      args:
+        arg:
+          type: string          # string | integer | number | boolean | array
+          description: ""
+          required: false
+          default: ""
+          enum: []
+      timeout: 30s</code></pre>
+
+  <h3>type: script</h3>
+  <pre><code>  tools:
+    - name: my_tool
+      description: What this tool does
+      source: scripts/my_tool.js   # path to JavaScript file
+      args:
+        arg:
+          type: string
+          required: false
+      timeout: 10s</code></pre>
+
+  <h2>outbound_auth</h2>
+  <pre><code># Bearer token
+outbound_auth:
+  strategy: bearer
+  bearer:
+    token: $&#123;API_TOKEN&#125;
+
+# OAuth2 Client Credentials
+outbound_auth:
+  strategy: oauth2_client_credentials
+  oauth2_client_credentials:
+    token_url: https://auth.example.com/oauth/token
+    client_id: $&#123;CLIENT_ID&#125;
+    client_secret: $&#123;CLIENT_SECRET&#125;
+    scopes: [read, write]
+
+# API key header
+outbound_auth:
+  strategy: api_key
+  api_key:
+    header: X-API-Key
+    value: $&#123;KEY&#125;
+
+# Lua
+outbound_auth:
+  strategy: lua
+  lua:
+    source: scripts/get_token.lua</code></pre>
+
+  <h2>transport (per-upstream)</h2>
+  <pre><code>transport:
+  timeout: 30s
+  max_idle_conns: 100
+  max_idle_conns_per_host: 10
+  idle_conn_timeout: 90s
+  http2: false
+  tls:
+    ca_cert: /etc/certs/ca.crt
+    client_cert: /etc/certs/client.crt
+    client_key: /etc/certs/client.key
+    server_name: ""
+    insecure_skip_verify: false
+  proxy:
+    url: socks5://proxy.internal:1080
+    username: $&#123;PROXY_USER&#125;
+    password: $&#123;PROXY_PASS&#125;</code></pre>
+
+  <h2>groups[]</h2>
+  <pre><code>groups:
+  - name: all               # group identifier
+    endpoint: /mcp          # MCP endpoint path
+    upstreams: [api, k8s]   # upstream names to include
+    filter: ""              # optional JSONPath filter for HTTP upstreams
+    transport:              # optional; inherits server.transport if omitted
+      - streamable-http
+    inbound_auth: ...       # optional; see Authentication</code></pre>
+
+  <h2>inbound_auth</h2>
+  <pre><code># JWT
+inbound_auth:
+  strategy: jwt
+  jwt:
+    issuer: https://auth.example.com
+    jwks_url: https://auth.example.com/.well-known/jwks.json
+    audience: my-proxy
+    algorithms: [RS256]
+
+# Token introspection
+inbound_auth:
+  strategy: introspection
+  introspection:
+    endpoint: https://auth.example.com/oauth/introspect
+    client_id: $&#123;CLIENT_ID&#125;
+    client_secret: $&#123;CLIENT_SECRET&#125;
+
+# API key
+inbound_auth:
+  strategy: apikey
+  apikey:
+    header: X-API-Key
+    value: $&#123;API_KEY&#125;
+
+# Lua
+inbound_auth:
+  strategy: lua
+  lua:
+    source: scripts/validate.lua
+
+# None
+inbound_auth:
+  strategy: none</code></pre>
+
+  <h2>telemetry</h2>
+  <pre><code>telemetry:
+  enabled: true
+  service_name: mcp-anything
+  service_version: ""
+  log_level: info            # debug | info | warn | error
+  traces:
+    exporter: otlp           # otlp | stdout | noop
+    endpoint: https://otel-collector:4318
+    insecure: false
+    headers:
+      Authorization: Bearer $&#123;OTEL_TOKEN&#125;
+  metrics:
+    exporter: prometheus     # prometheus | otlp | stdout
+    path: /metrics
+    port: 9090</code></pre>
+
+  <h2>Environment variable expansion</h2>
+  <p>Any value in the config can reference environment variables with <code>$&#123;VAR_NAME&#125;</code>. Variables are expanded at load time. Unset variables are expanded to empty string.</p>
+  <pre><code>upstreams:
+  - name: myapi
+    outbound_auth:
+      strategy: bearer
+      bearer:
+        token: $&#123;MY_API_TOKEN&#125;   # reads MY_API_TOKEN from environment</code></pre>
+
+  <h2>Complete example</h2>
+  <pre><code>server:
+  port: 8080
+  transport: [streamable-http, sse]
+
+upstreams:
+  - name: kraken
+    type: http
+    tool_prefix: kraken
+    base_url: https://api.kraken.com
+    openapi:
+      source: /etc/mcp-anything/specs/kraken.yaml
+      refresh_interval: 5m
+    overlay:
+      source: /etc/mcp-anything/overlays/kraken.yaml
+
+  - name: cluster
+    type: command
+    tool_prefix: k8s
+    tools:
+      - name: get_pods
+        description: List pods in a namespace
+        command: kubectl get pods -n &#123;&#123;namespace&#125;&#125; -o json
+        args:
+          namespace:
+            type: string
+            required: true
+        timeout: 30s
+
+groups:
+  - name: default
+    endpoint: /mcp
+    upstreams: [kraken, cluster]
+
+  - name: market
+    endpoint: /mcp/market
+    upstreams: [kraken]
+    inbound_auth:
+      strategy: jwt
+      jwt:
+        issuer: https://auth.example.com
+        jwks_url: https://auth.example.com/.well-known/jwks.json
+
+telemetry:
+  enabled: true
+  service_name: mcp-anything
+  traces:
+    exporter: otlp
+    endpoint: https://otel-collector:4318
+  metrics:
+    exporter: prometheus
+    path: /metrics
+    port: 9090</code></pre>
+</DocsLayout>

--- a/website/src/pages/docs/groups.astro
+++ b/website/src/pages/docs/groups.astro
@@ -1,0 +1,86 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Tool Groups"
+  description="Serve different tool subsets at different MCP endpoints using JSONPath filters. Create read-only, premium, or role-based views from the same upstreams."
+  current="groups"
+>
+  <h1>Tool Groups</h1>
+  <p class="lead">Groups let you expose different subsets of your upstreams at different MCP endpoints — all from the same running proxy. Use them to create read-only, tiered, or role-based views.</p>
+
+  <h2>Basic configuration</h2>
+  <pre><code>groups:
+  - name: all
+    endpoint: /mcp
+    upstreams: [kraken, cluster, ops]
+
+  - name: market
+    endpoint: /mcp/market
+    upstreams: [kraken]</code></pre>
+  <p>Each group has a unique <code>endpoint</code> path. MCP clients connect to their assigned endpoint and see only the tools from the listed upstreams.</p>
+
+  <h2>JSONPath filters</h2>
+  <p>The <code>filter</code> field is a JSONPath expression evaluated against each operation in the OpenAPI spec. Only operations that match the filter are included in the group's tools. Non-HTTP upstreams (command, script) are not filtered.</p>
+
+  <h3>Read-only group</h3>
+  <pre><code>groups:
+  - name: readonly
+    endpoint: /mcp/readonly
+    upstreams: [kraken]
+    filter: "$.paths.*[?(@['x-mcp-safe'] == true)]"</code></pre>
+  <p>This includes only operations where <code>x-mcp-safe: true</code> is set in the spec or overlay.</p>
+
+  <h3>Tier-based group</h3>
+  <pre><code>groups:
+  - name: premium
+    endpoint: /mcp/premium
+    upstreams: [myapi]
+    filter: "$.paths.*[?(@['x-mcp-tier'] == 'premium')]"</code></pre>
+
+  <h3>GET-only (all GET operations)</h3>
+  <pre><code>groups:
+  - name: get-only
+    endpoint: /mcp/get
+    upstreams: [myapi]
+    filter: "$.paths.*.get"</code></pre>
+
+  <h2>Group-level auth</h2>
+  <p>Combine groups with inbound auth to create access-controlled endpoints. Configure <code>inbound_auth</code> on each group independently:</p>
+  <pre><code>groups:
+  - name: public
+    endpoint: /mcp/public
+    upstreams: [kraken]
+    # no inbound_auth — open access
+
+  - name: internal
+    endpoint: /mcp/internal
+    upstreams: [kraken, cluster]
+    inbound_auth:
+      strategy: jwt
+      jwt:
+        issuer: https://auth.example.com
+        jwks_url: https://auth.example.com/.well-known/jwks.json</code></pre>
+
+  <h2>Transport per group</h2>
+  <p>Each group can specify which MCP transports to enable:</p>
+  <pre><code>groups:
+  - name: streaming
+    endpoint: /mcp
+    upstreams: [kraken]
+    transport:
+      - streamable-http
+      - sse</code></pre>
+  <p>Supported transports: <code>streamable-http</code>, <code>sse</code>.</p>
+
+  <h2>Default group</h2>
+  <p>If no <code>groups</code> are defined, the proxy creates a default group at <code>/mcp</code> that includes all upstreams with no filter.</p>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/overlays">OpenAPI Overlays</a> — set <code>x-mcp-safe</code> and <code>x-mcp-tier</code> on operations</li>
+    <li><a href="/docs/auth">Authentication</a> — per-group inbound auth strategies</li>
+    <li><a href="/docs/routing">Multi-Upstream Routing</a> — configure multiple upstreams</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/hot-reload.astro
+++ b/website/src/pages/docs/hot-reload.astro
@@ -1,0 +1,78 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Hot-Reload & Spec Refresh"
+  description="Config hot-reload with fsnotify and background OpenAPI spec refresh with ETag/conditional GET. Both are atomic and zero-downtime."
+  current="hot-reload"
+>
+  <h1>Hot-Reload &amp; Spec Refresh</h1>
+  <p class="lead">Config changes and OpenAPI spec updates are applied atomically at runtime without restarting the proxy or dropping in-flight requests.</p>
+
+  <h2>Config hot-reload</h2>
+  <p>The proxy watches the config file with <a href="https://github.com/fsnotify/fsnotify" target="_blank" rel="noopener noreferrer">fsnotify</a>. When a change is detected:</p>
+  <ol>
+    <li>The new config is parsed and validated</li>
+    <li>A new set of upstreams, tools, and groups is built</li>
+    <li>The new routing table is swapped in atomically</li>
+    <li>In-flight requests continue using the old routing table until they complete</li>
+  </ol>
+  <p>If the new config is invalid, the proxy logs the error and continues running with the current config.</p>
+
+  <h3>Kubernetes ConfigMap support</h3>
+  <p>Kubernetes updates ConfigMaps by atomically swapping a symlink to a new data directory. fsnotify detects the symlink change and triggers a reload. No special configuration is required.</p>
+  <pre><code># Mount config, specs, and overlays as separate ConfigMaps
+# for independent update cycles
+volumes:
+  - name: config
+    configMap:
+      name: mcp-anything-config
+  - name: specs
+    configMap:
+      name: mcp-anything-specs
+  - name: overlays
+    configMap:
+      name: mcp-anything-overlays</code></pre>
+
+  <h2>Background spec refresh</h2>
+  <p>HTTP upstreams can re-fetch their OpenAPI spec on a configurable interval:</p>
+  <pre><code>upstreams:
+  - name: myapi
+    type: http
+    openapi:
+      source: https://api.example.com/openapi.yaml
+      refresh_interval: 5m     # re-fetch every 5 minutes</code></pre>
+  <p>On each refresh:</p>
+  <ol>
+    <li>The proxy sends a conditional GET with the <code>If-None-Match</code> header (ETag from the previous response)</li>
+    <li>If the server returns <code>304 Not Modified</code>, no work is done</li>
+    <li>If the spec has changed, it is parsed, overlays are applied, tools are regenerated</li>
+    <li>The upstream's tool registry is swapped in atomically</li>
+  </ol>
+
+  <h3>Refresh intervals</h3>
+  <p>Valid duration formats: <code>30s</code>, <code>5m</code>, <code>1h</code>. If <code>refresh_interval</code> is not set, the spec is loaded once at startup and never re-fetched.</p>
+
+  <h3>Refresh on startup</h3>
+  <p>The proxy always loads specs on startup regardless of <code>refresh_interval</code>. If a spec fails to load at startup, the proxy refuses to start.</p>
+
+  <h2>Reload failures</h2>
+  <p>Config and spec reload failures are non-fatal — the proxy logs the error and continues with the previous valid state. This means a bad config push doesn't take down your MCP endpoint.</p>
+
+  <h2>Health and readiness</h2>
+  <p>The proxy exposes standard Kubernetes probes:</p>
+  <table>
+    <thead><tr><th>Path</th><th>Purpose</th></tr></thead>
+    <tbody>
+      <tr><td><code>GET /healthz</code></td><td>Liveness — returns 200 if the server is running</td></tr>
+      <tr><td><code>GET /readyz</code></td><td>Readiness — returns 200 when all upstreams are loaded and ready</td></tr>
+    </tbody>
+  </table>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/kubernetes">Kubernetes</a> — ConfigMap mounting and deployment patterns</li>
+    <li><a href="/docs/routing">Multi-Upstream Routing</a> — independent refresh cycles per upstream</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -1,0 +1,74 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Introduction"
+  description="Get started with mcp-anything — a stateless Go proxy that turns REST APIs, shell commands, and scripts into MCP tools."
+  current=""
+>
+  <h1>Introduction</h1>
+  <p class="lead">mcp-anything is a stateless Go proxy that converts REST APIs, shell commands, and JavaScript scripts into <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener noreferrer">MCP</a> tools — no code, no plugins, just a YAML config file.</p>
+
+  <h2>What it does</h2>
+  <p>Point it at an OpenAPI spec, a CLI tool, or a JavaScript file. The proxy generates MCP tools automatically and handles the full request lifecycle: auth, schema validation, request/response transforms, error mapping, and observability.</p>
+  <p>Any MCP-compatible client (Claude, Cursor, etc.) connects to <code>http://localhost:8080/mcp</code> and immediately has access to all configured tools.</p>
+
+  <h2>Quick start — Kraken Market Data</h2>
+  <p>The Kraken cryptocurrency exchange offers a public REST API with no authentication required. The repo includes a ready-to-use OpenAPI spec and overlay.</p>
+  <p><strong>1. Install</strong></p>
+  <pre><code>go install github.com/gaarutyunov/mcp-anything/cmd/proxy@latest</code></pre>
+  <p><strong>2. Create config.yaml</strong></p>
+  <pre><code>upstreams:
+  - name: kraken
+    type: http
+    tool_prefix: kraken
+    base_url: https://api.kraken.com
+    openapi:
+      source: deploy/examples/kraken/spec.yaml
+    overlay:
+      source: deploy/examples/kraken/overlay.yaml</code></pre>
+  <p><strong>3. Run the proxy</strong></p>
+  <pre><code>proxy --config config.yaml</code></pre>
+  <p>Your MCP client now has five tools:</p>
+  <table>
+    <thead><tr><th>Tool</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>kraken__get_system_status</code></td><td>Exchange status and server time</td></tr>
+      <tr><td><code>kraken__get_ticker</code></td><td>Real-time prices for any trading pair</td></tr>
+      <tr><td><code>kraken__get_ohlc</code></td><td>OHLC candlestick data</td></tr>
+      <tr><td><code>kraken__get_order_book</code></td><td>Live order book depth</td></tr>
+      <tr><td><code>kraken__get_recent_trades</code></td><td>Most recent public trades</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Three types of tools</h2>
+  <p>The proxy supports three upstream types that can be mixed in the same config:</p>
+  <ul>
+    <li><strong>HTTP</strong> — connect to any REST API with an OpenAPI 3.0 spec. Tools are auto-generated from operations. See <a href="/docs/openapi">HTTP APIs</a>.</li>
+    <li><strong>Command</strong> — wrap any CLI tool with typed arguments. See <a href="/docs/commands">Shell Commands</a>.</li>
+    <li><strong>Script</strong> — custom logic in a sandboxed JavaScript runtime. See <a href="/docs/scripts">JavaScript Scripts</a>.</li>
+  </ul>
+
+  <h2>Key concepts</h2>
+  <ul>
+    <li><strong>Stateless</strong> — no shared mutable state; every pod is identical</li>
+    <li><strong>Tool prefix</strong> — each upstream has a <code>tool_prefix</code>; tools are named <code>&#123;prefix&#125;__&#123;operation&#125;</code></li>
+    <li><strong>Overlays</strong> — customize any OpenAPI operation via RFC 9535 JSONPath without touching the original spec</li>
+    <li><strong>Groups</strong> — serve different tool subsets at different endpoints from the same upstreams</li>
+    <li><strong>Hot-reload</strong> — config and spec changes are applied atomically without restarting</li>
+  </ul>
+
+  <h2>Docker</h2>
+  <pre><code>docker run -p 8080:8080 \
+  -v $(pwd)/config.yaml:/etc/mcp-anything/config.yaml \
+  ghcr.io/gaarutyunov/mcp-anything:latest</code></pre>
+
+  <h2>What's next</h2>
+  <ul>
+    <li><a href="/docs/openapi">HTTP APIs (OpenAPI)</a> — how tool generation works</li>
+    <li><a href="/docs/overlays">OpenAPI Overlays</a> — customize tools without modifying specs</li>
+    <li><a href="/docs/auth">Authentication</a> — inbound and outbound auth strategies</li>
+    <li><a href="/docs/config">Config Reference</a> — all configuration fields</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/kubernetes.astro
+++ b/website/src/pages/docs/kubernetes.astro
@@ -1,0 +1,151 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Kubernetes & Helm"
+  description="MCPProxy and MCPUpstream CRDs, annotation-based auto-discovery, ConfigMap mounting, and the included Helm chart."
+  current="kubernetes"
+>
+  <h1>Kubernetes &amp; Helm</h1>
+  <p class="lead">mcp-anything is designed for Kubernetes. It ships with a Helm chart, <code>MCPProxy</code> and <code>MCPUpstream</code> CRDs, and an operator for declarative management.</p>
+
+  <h2>Deployment — Helm</h2>
+  <p>The quickest path to production is the included Helm chart:</p>
+  <pre><code>helm install mcp-anything ./charts/mcp-anything \
+  --namespace mcp \
+  --create-namespace \
+  -f deploy/examples/kraken/helm-values.yaml</code></pre>
+
+  <h2>Deployment — plain Kubernetes</h2>
+  <p>Mount the config as a ConfigMap and mount specs/overlays as separate ConfigMaps so they can be updated independently:</p>
+  <pre><code>apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-config
+data:
+  config.yaml: |
+    upstreams:
+      - name: kraken
+        type: http
+        tool_prefix: kraken
+        base_url: https://api.kraken.com
+        openapi:
+          source: /etc/mcp-anything/specs/spec.yaml
+        overlay:
+          source: /etc/mcp-anything/overlays/overlay.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-anything
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: proxy
+          image: ghcr.io/gaarutyunov/mcp-anything:latest
+          ports:
+            - containerPort: 8080
+              name: mcp
+            - containerPort: 9090
+              name: metrics
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mcp-anything/config.yaml
+              subPath: config.yaml
+            - name: specs
+              mountPath: /etc/mcp-anything/specs
+            - name: overlays
+              mountPath: /etc/mcp-anything/overlays
+      volumes:
+        - name: config
+          configMap:
+            name: mcp-config
+        - name: specs
+          configMap:
+            name: mcp-specs
+        - name: overlays
+          configMap:
+            name: mcp-overlays</code></pre>
+
+  <h2>Kubernetes Operator</h2>
+  <p>The operator watches <code>MCPProxy</code> and <code>MCPUpstream</code> custom resources and manages proxy deployments declaratively.</p>
+  <pre><code>apiVersion: mcp.gaarutyunov.github.io/v1alpha1
+kind: MCPUpstream
+metadata:
+  name: kraken
+spec:
+  type: http
+  toolPrefix: kraken
+  baseUrl: https://api.kraken.com
+  openapi:
+    source: /etc/mcp-anything/specs/spec.yaml
+  overlay:
+    source: /etc/mcp-anything/overlays/overlay.yaml</code></pre>
+  <pre><code>apiVersion: mcp.gaarutyunov.github.io/v1alpha1
+kind: MCPProxy
+metadata:
+  name: market-proxy
+spec:
+  upstreamSelector:
+    matchLabels:
+      app: market-data
+  server:
+    port: 8080
+    transport:
+      - streamable-http
+      - sse
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi</code></pre>
+
+  <h3>Install the operator</h3>
+  <pre><code>helm install mcp-operator ./charts/mcp-anything \
+  --set operator.enabled=true \
+  --namespace mcp-system \
+  --create-namespace</code></pre>
+
+  <h2>ConfigMap hot-reload</h2>
+  <p>Kubernetes updates ConfigMaps by atomically replacing a symlink. The proxy's fsnotify watcher detects this and reloads config and specs without restarting. There is no need for a restart annotation or a rolling update just to push a config change.</p>
+
+  <h2>RBAC</h2>
+  <p>The Helm chart creates a minimal <code>ServiceAccount</code> and <code>ClusterRole</code> for the operator:</p>
+  <pre><code># Required operator permissions
+rules:
+  - apiGroups: [mcp.gaarutyunov.github.io]
+    resources: [mcpproxies, mcpupstreams]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [apps]
+    resources: [deployments]
+    verbs: [get, list, watch, create, update, patch]</code></pre>
+
+  <h2>Health probes</h2>
+  <table>
+    <thead><tr><th>Path</th><th>Use as</th></tr></thead>
+    <tbody>
+      <tr><td><code>GET /healthz</code></td><td>livenessProbe</td></tr>
+      <tr><td><code>GET /readyz</code></td><td>readinessProbe</td></tr>
+    </tbody>
+  </table>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/hot-reload">Hot-Reload &amp; Spec Refresh</a> — how ConfigMap updates are detected</li>
+    <li><a href="/docs/telemetry">OpenTelemetry</a> — metrics scraping in Kubernetes</li>
+    <li><a href="/docs/transport">Gateway Transport</a> — mTLS and connection pooling for production upstreams</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/oauth2-sessions.astro
+++ b/website/src/pages/docs/oauth2-sessions.astro
@@ -1,0 +1,69 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Per-User OAuth2 Sessions"
+  description="Store and manage per-user upstream OAuth2 tokens in Postgres or Redis, enabling user-scoped authorization flows across MCP sessions."
+  current="oauth2-sessions"
+>
+  <h1>Per-User OAuth2 Sessions</h1>
+  <p class="lead">Standard outbound OAuth2 Client Credentials grants a single machine identity for all users. Per-user OAuth2 sessions instead store individual user tokens — obtained via Authorization Code flow — so each user accesses the upstream API with their own identity and permissions.</p>
+
+  <h2>When to use this</h2>
+  <ul>
+    <li>The upstream API enforces per-user scopes or data isolation</li>
+    <li>Audit logs on the upstream must show individual user identities</li>
+    <li>Users need to grant the proxy access to their own upstream accounts (e.g. GitHub, Google)</li>
+  </ul>
+
+  <h2>Configuration</h2>
+  <pre><code>upstreams:
+  - name: github
+    type: http
+    tool_prefix: gh
+    base_url: https://api.github.com
+    openapi:
+      source: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.yaml
+    outbound_auth:
+      strategy: oauth2_user_session
+      oauth2_user_session:
+        authorization_url: https://github.com/login/oauth/authorize
+        token_url: https://github.com/login/oauth/access_token
+        client_id: $&#123;GITHUB_CLIENT_ID&#125;
+        client_secret: $&#123;GITHUB_CLIENT_SECRET&#125;
+        scopes: [repo, read:user]
+        redirect_url: https://my-proxy.example.com/oauth2/callback
+        session_store:
+          backend: postgres           # postgres | redis
+          dsn: $&#123;SESSION_STORE_DSN&#125;
+
+session_server:
+  enabled: true
+  base_url: https://my-proxy.example.com   # used to build redirect URLs</code></pre>
+
+  <h2>Session stores</h2>
+  <table>
+    <thead><tr><th>Backend</th><th>DSN format</th><th>Notes</th></tr></thead>
+    <tbody>
+      <tr><td><code>postgres</code></td><td><code>postgres://user:pass@host/db</code></td><td>Tokens survive proxy restarts; suitable for production</td></tr>
+      <tr><td><code>redis</code></td><td><code>redis://host:6379/0</code></td><td>Fast; tokens lost if Redis is flushed without persistence</td></tr>
+      <tr><td><code>memory</code></td><td>—</td><td>No config required; tokens lost on restart — development only</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Authorization flow</h2>
+  <p>When an unauthenticated user calls a tool that requires a user session, the proxy returns an MCP error with a <code>login_url</code> field pointing to the upstream's OAuth2 authorization endpoint. The user visits that URL, grants access, and is redirected back to the proxy's callback endpoint. Subsequent tool calls from that user automatically use their stored token.</p>
+
+  <h2>Token refresh</h2>
+  <p>If the upstream provides a <code>refresh_token</code> the proxy will automatically refresh the access token before it expires. Refresh failures surface as MCP errors with a new <code>login_url</code>, prompting the user to re-authorize.</p>
+
+  <h2>User identity</h2>
+  <p>The user is identified by the JWT <code>sub</code> claim from inbound auth. Inbound auth must be configured when using per-user sessions. See <a href="/docs/auth">Authentication</a>.</p>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/auth">Authentication</a> — inbound auth (required) and other outbound strategies</li>
+    <li><a href="/docs/groups">Tool Groups</a> — per-group session configuration</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/openapi.astro
+++ b/website/src/pages/docs/openapi.astro
@@ -1,0 +1,101 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="HTTP APIs (OpenAPI)"
+  description="Auto-generate MCP tools from OpenAPI 3.0 specs with input schemas, jq transforms, and dry-run validation."
+  current="openapi"
+>
+  <h1>HTTP APIs (OpenAPI)</h1>
+  <p class="lead">Point the proxy at any OpenAPI 3.0 spec and it auto-generates MCP tools — one per enabled operation — with typed input schemas, jq response transforms, and config-time dry-run validation.</p>
+
+  <h2>Configuration</h2>
+  <pre><code>upstreams:
+  - name: kraken
+    type: http
+    tool_prefix: kraken
+    base_url: https://api.kraken.com
+    openapi:
+      source: deploy/examples/kraken/spec.yaml   # path or URL
+      refresh_interval: 5m                        # re-fetch spec periodically
+    overlay:
+      source: deploy/examples/kraken/overlay.yaml # optional customization</code></pre>
+
+  <p>The <code>source</code> field accepts a local file path or a remote URL (<code>https://</code>). Remote specs are fetched with ETag/conditional GET to minimize bandwidth on refresh.</p>
+
+  <h2>Tool naming</h2>
+  <p>Tool names are derived from the <code>operationId</code> in the spec, slugified and prefixed with the upstream's <code>tool_prefix</code>:</p>
+  <table>
+    <thead><tr><th>operationId</th><th>tool_prefix</th><th>Tool name</th></tr></thead>
+    <tbody>
+      <tr><td><code>getSystemStatus</code></td><td><code>kraken</code></td><td><code>kraken__get_system_status</code></td></tr>
+      <tr><td><code>getTicker</code></td><td><code>kraken</code></td><td><code>kraken__get_ticker</code></td></tr>
+      <tr><td><code>listPets</code></td><td><code>pets</code></td><td><code>pets__list_pets</code></td></tr>
+    </tbody>
+  </table>
+  <p>Names can be overridden with <code>x-mcp-tool-name</code> in an overlay. When multiple upstreams would produce the same tool name, a numeric suffix is appended automatically.</p>
+
+  <h2>Input schema generation</h2>
+  <p>The proxy builds MCP tool input schemas from OpenAPI parameter definitions:</p>
+  <ul>
+    <li>Path parameters, query parameters, and request body fields become tool arguments</li>
+    <li>Types, descriptions, enums, formats, and <code>required</code> flags are preserved</li>
+    <li>Synthetic examples are generated from <code>example</code>, <code>default</code>, <code>enum</code>, or format-specific patterns (e.g. <code>date</code>, <code>uuid</code>)</li>
+  </ul>
+
+  <h2>Response transforms</h2>
+  <p>jq expressions transform API responses before they are returned to the MCP client. The default transform is <code>.</code> (passthrough). Set <code>x-mcp-response-transform</code> in an overlay to customize:</p>
+  <pre><code># Flatten Kraken's nested result wrapper
+x-mcp-response-transform: >
+  .result | to_entries[0] | &#123;
+    pair: .key,
+    ask: .value.a[0],
+    bid: .value.b[0],
+    lastPrice: .value.c[0]
+  &#125;</code></pre>
+  <p>Request bodies can also be transformed with <code>x-mcp-request-transform</code>. Error responses use <code>x-mcp-error-transform</code>. All transforms are compiled and dry-run validated at startup.</p>
+
+  <h2>Non-JSON responses</h2>
+  <p>Set <code>x-mcp-response-format</code> to handle binary or media responses:</p>
+  <table>
+    <thead><tr><th>Value</th><th>MCP content type</th></tr></thead>
+    <tbody>
+      <tr><td><code>json</code> (default)</td><td><code>TextContent</code> with JSON string</td></tr>
+      <tr><td><code>text</code></td><td><code>TextContent</code></td></tr>
+      <tr><td><code>image</code></td><td><code>ImageContent</code> (base64)</td></tr>
+      <tr><td><code>audio</code></td><td><code>AudioContent</code> (base64)</td></tr>
+      <tr><td><code>binary</code></td><td><code>ResourceContent</code> (base64)</td></tr>
+      <tr><td><code>auto</code></td><td>Detected from <code>Content-Type</code></td></tr>
+    </tbody>
+  </table>
+
+  <h2>Disabling operations</h2>
+  <p>Set <code>x-mcp-enabled: false</code> on any operation in an overlay to exclude it from tool generation entirely. This does not affect the upstream API — the operation simply won't appear as an MCP tool.</p>
+
+  <h2>Dry-run validation</h2>
+  <p>At startup the proxy generates a synthetic request for every enabled operation using example values from the spec. If any jq transform or schema mapping fails, the proxy refuses to start and logs the offending operation. This catches misconfigured overlays before they reach production.</p>
+
+  <h2>x-mcp extensions reference</h2>
+  <table>
+    <thead><tr><th>Extension</th><th>Type</th><th>Default</th><th>Purpose</th></tr></thead>
+    <tbody>
+      <tr><td><code>x-mcp-enabled</code></td><td>bool</td><td><code>true</code></td><td>Include operation as a tool</td></tr>
+      <tr><td><code>x-mcp-tool-name</code></td><td>string</td><td>derived</td><td>Override generated tool name</td></tr>
+      <tr><td><code>x-mcp-auth-required</code></td><td>bool</td><td><code>true</code></td><td>Per-operation auth bypass</td></tr>
+      <tr><td><code>x-mcp-safe</code></td><td>bool</td><td><code>false</code></td><td>Mark as read-only for group filters</td></tr>
+      <tr><td><code>x-mcp-response-format</code></td><td>string</td><td><code>json</code></td><td>Response content type</td></tr>
+      <tr><td><code>x-mcp-request-transform</code></td><td>string</td><td>generated</td><td>jq expression for request body</td></tr>
+      <tr><td><code>x-mcp-response-transform</code></td><td>string</td><td><code>.</code></td><td>jq expression for response</td></tr>
+      <tr><td><code>x-mcp-error-transform</code></td><td>string</td><td>default</td><td>jq expression for error responses</td></tr>
+      <tr><td><code>x-mcp-tier</code></td><td>string</td><td>—</td><td>Arbitrary label for group filters</td></tr>
+    </tbody>
+  </table>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/overlays">OpenAPI Overlays</a> — add x-mcp extensions without touching specs</li>
+    <li><a href="/docs/hot-reload">Background Spec Refresh</a> — keep specs up to date automatically</li>
+    <li><a href="/docs/auth">Authentication</a> — outbound auth for protected APIs</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/overlays.astro
+++ b/website/src/pages/docs/overlays.astro
@@ -1,0 +1,124 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="OpenAPI Overlays"
+  description="Customize tool names, descriptions, jq transforms, and behavior via RFC 9535 JSONPath overlays without modifying the original spec."
+  current="overlays"
+>
+  <h1>OpenAPI Overlays</h1>
+  <p class="lead">Overlays let you customize how operations are exposed as MCP tools without touching the original OpenAPI spec. They follow the <a href="https://spec.openapis.org/overlay/v1.0.0" target="_blank" rel="noopener noreferrer">OpenAPI Overlay 1.0</a> format using RFC 9535 JSONPath targeting.</p>
+
+  <h2>Structure</h2>
+  <pre><code>overlay: 1.0.0
+info:
+  title: My Overlay
+  version: 1.0.0
+x-speakeasy-jsonpath: rfc9535      # required for RFC 9535 semantics
+
+actions:
+  - target: "$.paths[\"/pets\"].get"   # JSONPath targeting the operation
+    update:                             # merge these properties
+      x-mcp-tool-name: list_pets
+      x-mcp-safe: true
+
+  - target: "$.paths[\"/internal/metrics\"]"
+    remove: true                        # or remove the node entirely</code></pre>
+
+  <h2>Configuring an overlay</h2>
+  <pre><code>upstreams:
+  - name: kraken
+    type: http
+    tool_prefix: kraken
+    base_url: https://api.kraken.com
+    openapi:
+      source: deploy/examples/kraken/spec.yaml
+    overlay:
+      source: deploy/examples/kraken/overlay.yaml   # local path or URL</code></pre>
+
+  <h2>Common use cases</h2>
+
+  <h3>Override tool name</h3>
+  <pre><code>- target: "$.paths[\"/0/public/Ticker\"].get"
+  update:
+    x-mcp-tool-name: get_ticker</code></pre>
+
+  <h3>Improve tool description</h3>
+  <pre><code>- target: "$.paths[\"/0/public/Ticker\"].get"
+  update:
+    description: >
+      Get real-time ticker for any trading pair (e.g. XBTUSD).
+      Returns ask, bid, last price, 24h volume, VWAP, high, and low.</code></pre>
+
+  <h3>Flatten nested response with jq</h3>
+  <pre><code>- target: "$.paths[\"/0/public/Ticker\"].get"
+  update:
+    x-mcp-response-transform: >
+      .result | to_entries[0] | &#123;
+        pair: .key,
+        ask: .value.a[0],
+        bid: .value.b[0],
+        lastPrice: .value.c[0],
+        volume24h: .value.v[1]
+      &#125;</code></pre>
+
+  <h3>Disable an operation</h3>
+  <pre><code>- target: "$.paths[\"/admin/reset\"].post"
+  update:
+    x-mcp-enabled: false</code></pre>
+
+  <h3>Remove a path entirely</h3>
+  <pre><code>- target: "$.paths[\"/internal/debug\"]"
+  remove: true</code></pre>
+
+  <h3>Mark operations as safe (read-only)</h3>
+  <pre><code># Mark all GET operations as safe
+- target: "$.paths.*.get"
+  update:
+    x-mcp-safe: true</code></pre>
+
+  <h3>Skip auth for public endpoints</h3>
+  <pre><code>- target: "$.paths[\"/public/status\"].get"
+  update:
+    x-mcp-auth-required: false</code></pre>
+
+  <h3>Handle binary responses</h3>
+  <pre><code>- target: "$.paths[\"/images/&#123;id&#125;\"].get"
+  update:
+    x-mcp-response-format: image</code></pre>
+
+  <h2>Full x-mcp extension reference</h2>
+  <table>
+    <thead><tr><th>Extension</th><th>Type</th><th>Default</th><th>Purpose</th></tr></thead>
+    <tbody>
+      <tr><td><code>x-mcp-enabled</code></td><td>bool</td><td><code>true</code></td><td>Include operation as a tool</td></tr>
+      <tr><td><code>x-mcp-tool-name</code></td><td>string</td><td>derived</td><td>Override generated tool name</td></tr>
+      <tr><td><code>x-mcp-auth-required</code></td><td>bool</td><td><code>true</code></td><td>Per-operation auth bypass</td></tr>
+      <tr><td><code>x-mcp-safe</code></td><td>bool</td><td><code>false</code></td><td>Mark as read-only for group filters</td></tr>
+      <tr><td><code>x-mcp-response-format</code></td><td>string</td><td><code>json</code></td><td><code>json</code> | <code>text</code> | <code>image</code> | <code>audio</code> | <code>binary</code> | <code>auto</code></td></tr>
+      <tr><td><code>x-mcp-request-transform</code></td><td>string</td><td>generated</td><td>jq expression applied to request body</td></tr>
+      <tr><td><code>x-mcp-response-transform</code></td><td>string</td><td><code>.</code></td><td>jq expression applied to response body</td></tr>
+      <tr><td><code>x-mcp-error-transform</code></td><td>string</td><td>default</td><td>jq expression for error responses</td></tr>
+      <tr><td><code>x-mcp-tier</code></td><td>string</td><td>—</td><td>Arbitrary label for JSONPath group filters</td></tr>
+    </tbody>
+  </table>
+
+  <h2>JSONPath targeting tips</h2>
+  <ul>
+    <li>Target a specific operation: <code>$.paths["/pets/&#123;id&#125;"].get</code></li>
+    <li>Target all operations on a path: <code>$.paths["/pets/&#123;id&#125;"].*</code></li>
+    <li>Target all GET operations: <code>$.paths.*.get</code></li>
+    <li>Target all operations: <code>$.paths.*.*</code></li>
+    <li>Filter by extension: <code>$.paths.*[?(@['x-internal'] == true)]</code></li>
+  </ul>
+
+  <h2>Real-world example — Kraken</h2>
+  <p>The full overlay used by the Kraken example is at <a href="https://github.com/gaarutyunov/mcp-anything/blob/main/deploy/examples/kraken/overlay.yaml" target="_blank" rel="noopener noreferrer">deploy/examples/kraken/overlay.yaml</a>. It renames five operations and adds jq transforms that extract and rename fields from Kraken's compact array format.</p>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/openapi">HTTP APIs</a> — x-mcp extensions applied by overlays</li>
+    <li><a href="/docs/groups">Tool Groups</a> — filter tools using <code>x-mcp-safe</code> and <code>x-mcp-tier</code></li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/rate-limiting.astro
+++ b/website/src/pages/docs/rate-limiting.astro
@@ -1,0 +1,65 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Rate Limiting"
+  description="Token-bucket rate limiting per MCP tool with configurable sources (IP, user, session) and burst allowances."
+  current="rate-limiting"
+>
+  <h1>Rate Limiting</h1>
+  <p class="lead">The proxy enforces per-tool rate limits using a token-bucket algorithm. Limits can be keyed by client IP, authenticated user, or MCP session ID — independently for each tool.</p>
+
+  <h2>Configuration</h2>
+  <p>Rate limiting is configured per-upstream under <code>rate_limit</code>. Each entry targets one tool (by name or glob) and defines the bucket parameters:</p>
+  <pre><code>upstreams:
+  - name: myapi
+    type: http
+    tool_prefix: api
+    base_url: https://api.example.com
+    openapi:
+      source: spec.yaml
+    rate_limit:
+      - tool: "*"                 # applies to all tools in this upstream
+        rate: 60                  # tokens per interval
+        interval: 1m              # refill interval
+        burst: 10                 # maximum burst above steady rate
+        source: user              # key by: ip | user | session | global</code></pre>
+
+  <h2>Limit sources</h2>
+  <table>
+    <thead><tr><th>Source</th><th>Key used</th><th>When to use</th></tr></thead>
+    <tbody>
+      <tr><td><code>ip</code></td><td>Client IP address</td><td>Unauthenticated endpoints; coarse throttling</td></tr>
+      <tr><td><code>user</code></td><td>JWT <code>sub</code> claim or API key identity</td><td>Per-user quotas on authenticated endpoints</td></tr>
+      <tr><td><code>session</code></td><td>MCP session ID</td><td>Isolate AI agent sessions from each other</td></tr>
+      <tr><td><code>global</code></td><td>Shared across all callers</td><td>Protect an upstream with a hard cap</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Per-tool overrides</h2>
+  <p>Use the tool name (with prefix) or a glob to apply limits selectively. More specific patterns take precedence over wildcards:</p>
+  <pre><code>rate_limit:
+  - tool: "*"
+    rate: 100
+    interval: 1m
+    source: user
+  - tool: "api__export_data"      # tighter limit for expensive operation
+    rate: 5
+    interval: 1m
+    burst: 2
+    source: user</code></pre>
+
+  <h2>Rate limit responses</h2>
+  <p>When a tool call exceeds its limit the proxy returns an MCP error with code <code>-32029</code> (rate limit exceeded) and a <code>Retry-After</code> hint in seconds. The MCP client receives a structured error — it is never silently dropped.</p>
+
+  <h2>Metrics</h2>
+  <p>Rate limit decisions are emitted as OpenTelemetry metrics under the <code>mcp.ratelimit.*</code> namespace. The <code>mcp.ratelimit.rejected</code> counter is labelled by tool name and source key. See <a href="/docs/telemetry">OpenTelemetry</a> for the full metrics reference.</p>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/circuit-breaking">Circuit Breaking</a> — upstream failure protection</li>
+    <li><a href="/docs/telemetry">OpenTelemetry</a> — metrics and traces</li>
+    <li><a href="/docs/auth">Authentication</a> — user identity for <code>user</code>-keyed limits</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/routing.astro
+++ b/website/src/pages/docs/routing.astro
@@ -1,0 +1,88 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Multi-Upstream Routing"
+  description="Proxy multiple HTTP, command, and script backends from a single mcp-anything instance with prefix-based tool namespacing."
+  current="routing"
+>
+  <h1>Multi-Upstream Routing</h1>
+  <p class="lead">A single proxy instance can aggregate tools from multiple backends — HTTP APIs, CLI commands, and JavaScript scripts — served through one MCP endpoint.</p>
+
+  <h2>How it works</h2>
+  <p>Each upstream declares a <code>tool_prefix</code>. Tool names follow the pattern <code>&#123;prefix&#125;__&#123;operation&#125;</code>, using a double-underscore separator. This ensures tools from different upstreams never collide.</p>
+  <pre><code>upstreams:
+  - name: kraken
+    type: http
+    tool_prefix: kraken            # → kraken__get_ticker, kraken__get_ohlc, ...
+    base_url: https://api.kraken.com
+    openapi:
+      source: deploy/examples/kraken/spec.yaml
+
+  - name: cluster
+    type: command
+    tool_prefix: k8s               # → k8s__get_pods, k8s__get_logs, ...
+    tools:
+      - name: get_pods
+        command: kubectl get pods -n &#123;&#123;namespace&#125;&#125; -o json
+        args:
+          namespace:
+            type: string
+            required: true
+
+  - name: ops
+    type: script
+    tool_prefix: ops               # → ops__health_check, ...
+    tools:
+      - name: health_check
+        source: scripts/health_check.js
+        args:
+          service:
+            type: string</code></pre>
+
+  <h2>Tool name collision handling</h2>
+  <p>If two upstreams would produce identical tool names after prefixing, a numeric suffix (<code>_2</code>, <code>_3</code>) is appended to the later upstream's tools. Use distinct <code>tool_prefix</code> values or <code>x-mcp-tool-name</code> overlays to avoid this.</p>
+
+  <h2>Upstream types</h2>
+  <table>
+    <thead><tr><th>Type</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>http</code></td><td>REST API backed by an OpenAPI 3.0 spec</td></tr>
+      <tr><td><code>command</code></td><td>Shell command with template argument interpolation</td></tr>
+      <tr><td><code>script</code></td><td>JavaScript file running in a Sobek sandbox</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Groups</h2>
+  <p>Use <a href="/docs/groups">Tool Groups</a> to expose different subsets of upstreams at different MCP endpoints from the same proxy instance:</p>
+  <pre><code>groups:
+  - name: all
+    endpoint: /mcp
+    upstreams: [kraken, cluster, ops]
+
+  - name: market-only
+    endpoint: /mcp/market
+    upstreams: [kraken]</code></pre>
+
+  <h2>Independent refresh cycles</h2>
+  <p>Each HTTP upstream can have its own <code>refresh_interval</code>. When a spec is re-fetched and parsed, the upstream's tools are updated atomically without affecting other upstreams or dropping in-flight requests.</p>
+  <pre><code>upstreams:
+  - name: fast-api
+    type: http
+    openapi:
+      source: https://api.example.com/openapi.yaml
+      refresh_interval: 1m     # refresh every minute
+
+  - name: stable-api
+    type: http
+    openapi:
+      source: https://stable.example.com/openapi.yaml
+      refresh_interval: 1h     # refresh hourly</code></pre>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/groups">Tool Groups</a> — filter and segment upstreams into separate endpoints</li>
+    <li><a href="/docs/hot-reload">Hot-Reload &amp; Spec Refresh</a> — how config and spec updates are applied</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/scripts.astro
+++ b/website/src/pages/docs/scripts.astro
@@ -1,0 +1,107 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="JavaScript Scripts"
+  description="Custom tool logic in a sandboxed Sobek JavaScript runtime with ctx.fetch(), ctx.env, and ctx.log()."
+  current="scripts"
+>
+  <h1>JavaScript Scripts</h1>
+  <p class="lead">Write custom MCP tools in JavaScript. Scripts run in a sandboxed <a href="https://github.com/grafana/sobek" target="_blank" rel="noopener noreferrer">Sobek</a> runtime — no Node.js, no npm, no filesystem access by default.</p>
+
+  <h2>Configuration</h2>
+  <pre><code>upstreams:
+  - name: custom
+    type: script
+    tool_prefix: ops
+    tools:
+      - name: health_check
+        description: Check service health across regions
+        source: scripts/health_check.js
+        args:
+          service:
+            type: string
+            description: Service name
+            required: true
+          region:
+            type: string
+            description: AWS region
+            default: us-east-1
+        timeout: 10s</code></pre>
+
+  <h2>Script context</h2>
+  <p>Scripts receive a <code>ctx</code> object and an <code>args</code> object containing the typed arguments declared in the config.</p>
+  <pre><code>// scripts/health_check.js
+
+const url = `https://$&#123;args.service&#125;.internal/$&#123;args.region&#125;/health`;
+
+const resp = await ctx.fetch(url, &#123;
+  method: 'GET',
+  headers: &#123; 'X-Service': args.service &#125;,
+&#125;);
+
+if (!resp.ok) &#123;
+  return &#123; status: 'unhealthy', code: resp.status &#125;;
+&#125;
+
+const body = await resp.json();
+return &#123; status: 'healthy', ...body &#125;;</code></pre>
+
+  <h2>Available APIs</h2>
+  <table>
+    <thead><tr><th>API</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>ctx.fetch(url, options)</code></td><td>HTTP client — same signature as the Web Fetch API. Returns a Response.</td></tr>
+      <tr><td><code>ctx.env(name)</code></td><td>Read an environment variable by name. Returns string or null.</td></tr>
+      <tr><td><code>ctx.log(message, ...args)</code></td><td>Write to the proxy's structured logger (slog). Appears in proxy logs.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Return value</h2>
+  <p>Return any JSON-serializable value. Objects, arrays, strings, and numbers are all valid. The return value becomes the tool result sent to the MCP client.</p>
+  <p>Throw an <code>Error</code> to signal a tool failure. The error message is forwarded to the client.</p>
+  <pre><code>// Return an object
+return &#123; price: 42.0, currency: 'USD' &#125;;
+
+// Return an array
+return items.map(i => (&#123; id: i.id, name: i.name &#125;));
+
+// Signal an error
+throw new Error('Service unavailable: ' + resp.status);</code></pre>
+
+  <h2>Async/await</h2>
+  <p>Scripts are executed as async functions. <code>await</code> is supported for <code>ctx.fetch()</code> and any Promise-returning expression.</p>
+
+  <h2>Timeout</h2>
+  <p>The <code>timeout</code> field limits total script execution time including any <code>ctx.fetch()</code> calls. Scripts that exceed the timeout are interrupted and an error is returned.</p>
+
+  <h2>Security sandbox</h2>
+  <p>The Sobek runtime does not expose Node.js globals, filesystem access, or process manipulation. Scripts can only:</p>
+  <ul>
+    <li>Read arguments passed in via <code>args</code></li>
+    <li>Make HTTP calls via <code>ctx.fetch()</code></li>
+    <li>Read env vars explicitly via <code>ctx.env()</code></li>
+    <li>Log via <code>ctx.log()</code></li>
+    <li>Use standard ECMAScript built-ins (JSON, Date, Math, etc.)</li>
+  </ul>
+
+  <h2>Example: multi-service aggregation</h2>
+  <pre><code>// Fetch from multiple services in parallel and aggregate
+const [prices, inventory] = await Promise.all([
+  ctx.fetch('https://prices.internal/api/current').then(r => r.json()),
+  ctx.fetch('https://inventory.internal/api/stock').then(r => r.json()),
+]);
+
+return prices.items.map(item => (&#123;
+  sku: item.sku,
+  price: item.price,
+  inStock: inventory[item.sku] > 0,
+&#125;));</code></pre>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/commands">Shell Commands</a> — simpler option for wrapping CLI tools</li>
+    <li><a href="/docs/auth">Authentication</a> — pass auth tokens to <code>ctx.fetch()</code> via <code>ctx.env()</code></li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/sdk.astro
+++ b/website/src/pages/docs/sdk.astro
@@ -1,0 +1,114 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Go SDK"
+  description="Embed mcp-anything as a Go library. Register custom tool providers via the registry pattern. Tree-shaking keeps binaries lean."
+  current="sdk"
+>
+  <h1>Go SDK</h1>
+  <p class="lead">mcp-anything is library-first. You can embed the proxy in your own Go binary, register custom tool providers, and import only the auth strategies and upstream types you need.</p>
+
+  <h2>Embedding the proxy</h2>
+  <pre><code>import (
+    "context"
+    mcpanything "github.com/gaarutyunov/mcp-anything/pkg/mcpanything"
+    _ "github.com/gaarutyunov/mcp-anything/pkg/auth/inbound/all"   // all inbound strategies
+    _ "github.com/gaarutyunov/mcp-anything/pkg/auth/outbound/all"  // all outbound strategies
+    _ "github.com/gaarutyunov/mcp-anything/pkg/upstream/all"       // all upstream types
+)
+
+func main() &#123;
+    proxy, err := mcpanything.New(ctx, mcpanything.Options&#123;
+        ConfigPath: "/etc/mcp-anything/config.yaml",
+    &#125;)
+    if err != nil &#123;
+        log.Fatal(err)
+    &#125;
+    if err := proxy.Start(ctx); err != nil &#123;
+        log.Fatal(err)
+    &#125;
+&#125;</code></pre>
+
+  <h2>Registry pattern</h2>
+  <p>Every pluggable component — auth strategies, upstream types, embedding providers — follows the registry pattern. Components register themselves via <code>init()</code>, which runs only when the package is imported. If you don't import a package, its code is not linked into the binary.</p>
+
+  <h3>Importing only what you need</h3>
+  <pre><code>// Import only JWT inbound auth and OAuth2 outbound auth
+import (
+    _ "github.com/gaarutyunov/mcp-anything/pkg/auth/inbound/jwt"
+    _ "github.com/gaarutyunov/mcp-anything/pkg/auth/outbound/oauth2"
+    // Lua and JavaScript strategies are NOT linked
+)
+
+// Import only HTTP upstream type
+import (
+    _ "github.com/gaarutyunov/mcp-anything/pkg/upstream/http"
+    // command and script upstreams are NOT linked
+)</code></pre>
+
+  <h3>All-in-one bundles</h3>
+  <pre><code>// Import everything
+import _ "github.com/gaarutyunov/mcp-anything/pkg/auth/inbound/all"
+import _ "github.com/gaarutyunov/mcp-anything/pkg/auth/outbound/all"
+import _ "github.com/gaarutyunov/mcp-anything/pkg/upstream/all"</code></pre>
+
+  <h2>Registering a custom upstream type</h2>
+  <pre><code>package myupstream
+
+import (
+    "context"
+    "github.com/gaarutyunov/mcp-anything/pkg/upstream"
+    "github.com/gaarutyunov/mcp-anything/pkg/config"
+)
+
+func init() &#123;
+    upstream.Register("my-type", func(ctx context.Context, cfg *config.UpstreamConfig) (upstream.Provider, error) &#123;
+        return &MyProvider&#123;cfg: cfg&#125;, nil
+    &#125;)
+&#125;
+
+type MyProvider struct &#123;
+    cfg *config.UpstreamConfig
+&#125;
+
+func (p *MyProvider) Tools(ctx context.Context) ([]mcp.Tool, error) &#123;
+    // return your custom tools
+&#125;
+
+func (p *MyProvider) Call(ctx context.Context, name string, args map[string]any) (*mcp.CallToolResult, error) &#123;
+    // handle tool calls
+&#125;</code></pre>
+  <p>Then import it in your binary:</p>
+  <pre><code>import _ "github.com/myorg/myproject/myupstream"</code></pre>
+
+  <h2>Registering a custom inbound auth strategy</h2>
+  <pre><code>package myauth
+
+import (
+    "context"
+    "github.com/gaarutyunov/mcp-anything/pkg/auth/inbound"
+    "github.com/gaarutyunov/mcp-anything/pkg/config"
+)
+
+func init() &#123;
+    inbound.Register("my-strategy", func(ctx context.Context, cfg *config.InboundAuthConfig) (inbound.TokenValidator, string, error) &#123;
+        return &MyValidator&#123;&#125;, "my-strategy", nil
+    &#125;)
+&#125;</code></pre>
+
+  <h2>Tree-shaking</h2>
+  <p>Go's linker excludes packages that are never imported. The <code>tests/treeshake/</code> directory contains build-tag-isolated programs that verify importing only specific sub-packages does not pull in unrelated heavy dependencies (e.g. Sobek JavaScript runtime, gopher-lua).</p>
+  <p>When adding a new strategy or upstream type, add a treeshake test to verify isolation.</p>
+
+  <h2>Module</h2>
+  <pre><code>go get github.com/gaarutyunov/mcp-anything@latest</code></pre>
+  <p>Module path: <code>github.com/gaarutyunov/mcp-anything</code></p>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/auth">Authentication</a> — built-in inbound and outbound strategies</li>
+    <li><a href="/docs/routing">Multi-Upstream Routing</a> — upstream type configuration</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/search.astro
+++ b/website/src/pages/docs/search.astro
@@ -1,0 +1,57 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Semantic Tool Search"
+  description="AI-powered tool discovery via an in-process chromem-go vector index. MCP clients can find the right tool by description rather than exact name."
+  current="search"
+>
+  <h1>Semantic Tool Search</h1>
+  <p class="lead">When hundreds of tools are registered, finding the right one by name becomes impractical. The proxy can build an in-process vector index using <a href="https://github.com/philippgille/chromem-go" target="_blank" rel="noopener noreferrer">chromem-go</a> so MCP clients can search tools by natural-language description.</p>
+
+  <h2>How it works</h2>
+  <p>At startup the proxy embeds each tool's name, description, and parameter descriptions into a vector index. When an MCP client calls the synthetic <code>search_tools</code> tool with a query, the proxy performs a cosine-similarity search and returns the most relevant tool definitions — not results, just the schemas so the client can decide which tool to call next.</p>
+
+  <h2>Configuration</h2>
+  <pre><code>search:
+  enabled: true
+  embedding:
+    provider: openai               # openai | local
+    model: text-embedding-3-small  # OpenAI embedding model
+    api_key: $&#123;OPENAI_API_KEY&#125;
+  top_k: 5                         # number of results to return</code></pre>
+
+  <h3>Local embeddings (no external API)</h3>
+  <p>Use the <code>local</code> provider to run embeddings in-process with no outbound calls. This uses a built-in lightweight model and is suitable for smaller tool sets.</p>
+  <pre><code>search:
+  enabled: true
+  embedding:
+    provider: local
+  top_k: 10</code></pre>
+
+  <h2>The search_tools tool</h2>
+  <p>When search is enabled a special tool named <code>search_tools</code> is registered at the group level. MCP clients call it like any other tool:</p>
+  <pre><code># MCP tool call (JSON-RPC)
+&#123;
+  "name": "search_tools",
+  "arguments": &#123;
+    "query": "get current price of a cryptocurrency",
+    "top_k": 3
+  &#125;
+&#125;</code></pre>
+  <p>The response is a list of matching tool schemas (name, description, inputSchema) ranked by similarity score. The client then calls the best match directly.</p>
+
+  <h2>Index refresh</h2>
+  <p>The index is rebuilt whenever the tool registry changes — on hot-reload or background spec refresh. Rebuilds are atomic: the old index serves requests until the new one is ready.</p>
+
+  <h2>Groups</h2>
+  <p>Each group gets its own index scoped to its tool set. A group with a read-only subset only finds read-only tools. See <a href="/docs/groups">Tool Groups</a>.</p>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/groups">Tool Groups</a> — scope search to a subset of tools</li>
+    <li><a href="/docs/hot-reload">Hot-Reload</a> — index rebuilt on config change</li>
+    <li><a href="/docs/sdk">Go SDK</a> — register a custom embedding provider</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/telemetry.astro
+++ b/website/src/pages/docs/telemetry.astro
@@ -1,0 +1,99 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="OpenTelemetry"
+  description="OTLP traces with MCP-specific span attributes, Prometheus metrics, and W3C Trace Context propagation."
+  current="telemetry"
+>
+  <h1>OpenTelemetry</h1>
+  <p class="lead">The proxy emits OTLP traces, Prometheus metrics, and structured logs. W3C Trace Context is propagated to upstream APIs so distributed traces span your entire stack.</p>
+
+  <h2>Configuration</h2>
+  <pre><code>telemetry:
+  enabled: true
+  service_name: mcp-anything
+  service_version: 1.0.0
+
+  traces:
+    exporter: otlp
+    endpoint: https://otel-collector.internal:4318  # OTLP HTTP
+    insecure: false
+    headers:
+      Authorization: Bearer $&#123;OTEL_TOKEN&#125;
+
+  metrics:
+    exporter: prometheus
+    path: /metrics    # Prometheus scrape endpoint
+    port: 9090</code></pre>
+
+  <h2>Traces</h2>
+  <p>Each MCP tool call produces a trace with spans covering the full request lifecycle:</p>
+  <ul>
+    <li>MCP protocol handling (request parsing, tool lookup)</li>
+    <li>Auth validation (inbound and outbound)</li>
+    <li>Request transform (jq expression)</li>
+    <li>Upstream HTTP call</li>
+    <li>Response transform (jq expression)</li>
+  </ul>
+
+  <h3>MCP-specific span attributes</h3>
+  <table>
+    <thead><tr><th>Attribute</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>mcp.tool.name</code></td><td>Full tool name (e.g. <code>kraken__get_ticker</code>)</td></tr>
+      <tr><td><code>mcp.tool.upstream</code></td><td>Upstream name</td></tr>
+      <tr><td><code>mcp.transport</code></td><td><code>streamable-http</code> or <code>sse</code></td></tr>
+      <tr><td><code>http.upstream.url</code></td><td>URL of the upstream request</td></tr>
+      <tr><td><code>http.upstream.status_code</code></td><td>HTTP status from upstream</td></tr>
+    </tbody>
+  </table>
+
+  <h3>W3C Trace Context propagation</h3>
+  <p>The proxy injects <code>traceparent</code> and <code>tracestate</code> headers into upstream HTTP requests. If the upstream is also instrumented with OTel, traces from the MCP client through to the upstream API appear as a single distributed trace.</p>
+
+  <h2>Metrics</h2>
+  <p>When the Prometheus exporter is enabled, metrics are available at the configured path:</p>
+  <table>
+    <thead><tr><th>Metric</th><th>Type</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>mcp_tool_calls_total</code></td><td>Counter</td><td>Total tool calls by tool name and status</td></tr>
+      <tr><td><code>mcp_tool_call_duration_seconds</code></td><td>Histogram</td><td>Tool call latency distribution</td></tr>
+      <tr><td><code>mcp_upstream_requests_total</code></td><td>Counter</td><td>HTTP requests to upstreams</td></tr>
+      <tr><td><code>mcp_upstream_request_duration_seconds</code></td><td>Histogram</td><td>Upstream HTTP latency</td></tr>
+      <tr><td><code>mcp_active_connections</code></td><td>Gauge</td><td>Active MCP client connections</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Trace exporters</h2>
+  <table>
+    <thead><tr><th>Exporter</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>otlp</code></td><td>OTLP over HTTP (default port 4318)</td></tr>
+      <tr><td><code>stdout</code></td><td>Print traces to stdout (development)</td></tr>
+      <tr><td><code>noop</code></td><td>Discard all traces</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Metric exporters</h2>
+  <table>
+    <thead><tr><th>Exporter</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>prometheus</code></td><td>Prometheus scrape endpoint</td></tr>
+      <tr><td><code>otlp</code></td><td>Push metrics via OTLP</td></tr>
+      <tr><td><code>stdout</code></td><td>Print metrics to stdout (development)</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Structured logging</h2>
+  <p>The proxy logs via Go's <code>slog</code> package in JSON format. Log level is configurable:</p>
+  <pre><code>telemetry:
+  log_level: info    # debug, info, warn, error</code></pre>
+  <p>Secret values (tokens, credentials) are never logged. Config fields that reference <code>$&#123;ENV_VAR&#125;</code> secrets show the variable reference, not the expanded value.</p>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/kubernetes">Kubernetes</a> — configuring OTel collector sidecars</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/token-counting.astro
+++ b/website/src/pages/docs/token-counting.astro
@@ -1,0 +1,55 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Token Counting"
+  description="Per-tool token counting measures response sizes before they reach the MCP client, emitting metrics and optionally truncating oversized results."
+  current="token-counting"
+>
+  <h1>Token Counting</h1>
+  <p class="lead">Large tool results consume significant context window space in the calling LLM. The proxy counts tokens in every tool response before it is returned to the MCP client, emitting per-tool metrics and optionally enforcing size limits.</p>
+
+  <h2>How it works</h2>
+  <p>After any jq response transform is applied, the proxy tokenizes the result using a tiktoken-compatible tokenizer. The token count is attached to the active OpenTelemetry span and emitted as a histogram metric. No result content is logged.</p>
+
+  <h2>Configuration</h2>
+  <pre><code>token_counting:
+  enabled: true
+  model: gpt-4o           # tokenizer model (used for byte-pair encoding)
+  max_tokens: 8192        # optional: reject results that exceed this limit</code></pre>
+
+  <h3>Per-tool limit override</h3>
+  <p>Set a per-operation limit via the <code>x-mcp-max-tokens</code> extension in an overlay:</p>
+  <pre><code>- target: "$.paths[\"/search\"].get"
+  update:
+    x-mcp-max-tokens: 2048    # tighter limit for a high-cardinality search endpoint</code></pre>
+
+  <h2>What happens when a result exceeds the limit</h2>
+  <p>By default the proxy returns an MCP error instructing the client to narrow its query. Set <code>truncate: true</code> to truncate the result to the limit instead:</p>
+  <pre><code>token_counting:
+  enabled: true
+  max_tokens: 8192
+  truncate: true       # truncate instead of rejecting oversized results</code></pre>
+  <p>Truncation operates on the post-transform JSON string at the token boundary, then appends a <code>…[truncated]</code> marker so the client knows the result is incomplete.</p>
+
+  <h2>Metrics</h2>
+  <p>Token counts are emitted as an OpenTelemetry histogram <code>mcp.tool.response_tokens</code> with a <code>tool</code> label. This lets you observe which tools are burning the most context budget over time in your Prometheus/Grafana stack. See <a href="/docs/telemetry">OpenTelemetry</a>.</p>
+
+  <h2>Supported tokenizers</h2>
+  <table>
+    <thead><tr><th>Model value</th><th>Encoding</th></tr></thead>
+    <tbody>
+      <tr><td><code>gpt-4o</code></td><td>o200k_base</td></tr>
+      <tr><td><code>gpt-4</code>, <code>gpt-3.5-turbo</code></td><td>cl100k_base</td></tr>
+      <tr><td><code>claude-3</code></td><td>approximated via cl100k_base</td></tr>
+    </tbody>
+  </table>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/caching">Tool Result Caching</a> — avoid re-fetching large results</li>
+    <li><a href="/docs/telemetry">OpenTelemetry</a> — full metrics reference</li>
+    <li><a href="/docs/overlays">OpenAPI Overlays</a> — per-operation limits</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/transport.astro
+++ b/website/src/pages/docs/transport.astro
@@ -1,0 +1,94 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="Gateway Transport"
+  description="Connection pooling, mTLS, HTTP/2, TLS session caching, and SOCKS5 proxy for production-grade upstream connectivity."
+  current="transport"
+>
+  <h1>Gateway Transport</h1>
+  <p class="lead">The proxy's HTTP client for upstream connections supports connection pooling, mTLS, HTTP/2, TLS session caching, and SOCKS5 proxy — configurable per-upstream.</p>
+
+  <h2>Configuration</h2>
+  <pre><code>upstreams:
+  - name: myapi
+    type: http
+    tool_prefix: api
+    base_url: https://api.internal
+    openapi:
+      source: https://api.internal/openapi.yaml
+    transport:
+      timeout: 30s
+      max_idle_conns: 100
+      max_idle_conns_per_host: 10
+      idle_conn_timeout: 90s
+      tls:
+        ca_cert: /etc/certs/ca.crt
+        client_cert: /etc/certs/client.crt
+        client_key: /etc/certs/client.key
+        insecure_skip_verify: false
+      http2: true</code></pre>
+
+  <h2>Connection pooling</h2>
+  <table>
+    <thead><tr><th>Field</th><th>Default</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>max_idle_conns</code></td><td>100</td><td>Maximum idle connections across all hosts</td></tr>
+      <tr><td><code>max_idle_conns_per_host</code></td><td>10</td><td>Maximum idle connections per host</td></tr>
+      <tr><td><code>idle_conn_timeout</code></td><td>90s</td><td>How long idle connections are kept open</td></tr>
+      <tr><td><code>timeout</code></td><td>30s</td><td>Total request timeout (including response body read)</td></tr>
+    </tbody>
+  </table>
+
+  <h2>TLS / mTLS</h2>
+  <p>Configure per-upstream TLS for one-way TLS or mutual TLS (mTLS):</p>
+  <pre><code>transport:
+  tls:
+    ca_cert: /etc/certs/ca.crt        # custom CA for upstream
+    client_cert: /etc/certs/client.crt # mTLS client cert
+    client_key: /etc/certs/client.key  # mTLS client key
+    server_name: api.internal          # override SNI
+    insecure_skip_verify: false        # never set true in production</code></pre>
+  <p>Certificate files are read at startup. Rotate certs by updating the files and triggering a config reload — no restart required.</p>
+
+  <h2>HTTP/2</h2>
+  <pre><code>transport:
+  http2: true    # enable HTTP/2 for this upstream (default: false)</code></pre>
+  <p>HTTP/2 is negotiated via ALPN. The upstream must support it.</p>
+
+  <h2>TLS session caching</h2>
+  <p>TLS session tickets are cached automatically when HTTP/2 or persistent connections are used. This reduces TLS handshake overhead for high-throughput upstreams.</p>
+
+  <h2>SOCKS5 proxy</h2>
+  <pre><code>transport:
+  proxy:
+    url: socks5://proxy.internal:1080
+    username: $&#123;PROXY_USER&#125;
+    password: $&#123;PROXY_PASS&#125;</code></pre>
+  <p>All upstream connections for this upstream will be routed through the SOCKS5 proxy.</p>
+
+  <h2>Per-upstream defaults</h2>
+  <p>Each upstream has its own independent HTTP client. Transport settings from one upstream do not affect others.</p>
+
+  <h2>MCP transports</h2>
+  <p>The proxy itself also exposes MCP over two transports (configured under <code>server</code>):</p>
+  <table>
+    <thead><tr><th>Transport</th><th>Description</th></tr></thead>
+    <tbody>
+      <tr><td><code>streamable-http</code></td><td>HTTP with streaming responses (MCP default)</td></tr>
+      <tr><td><code>sse</code></td><td>Server-Sent Events for clients that prefer SSE</td></tr>
+    </tbody>
+  </table>
+  <pre><code>server:
+  port: 8080
+  transport:
+    - streamable-http
+    - sse</code></pre>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="/docs/auth">Authentication</a> — outbound auth (separate from TLS)</li>
+    <li><a href="/docs/kubernetes">Kubernetes</a> — mounting TLS certs as Secrets</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/ui.astro
+++ b/website/src/pages/docs/ui.astro
@@ -1,0 +1,82 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout
+  title="MCP Apps"
+  description="Return interactive HTML interfaces from OpenAPI-generated tools that render inside the MCP host (Claude Desktop, VS Code, etc.) — no separate web app required."
+  current="ui"
+>
+  <h1>MCP Apps</h1>
+  <p class="lead"><a href="https://modelcontextprotocol.io/extensions/apps/overview" target="_blank" rel="noopener noreferrer">MCP Apps</a> are interactive HTML UIs that render directly inside the MCP host — Claude Desktop, VS Code Copilot, or any other supporting client. Instead of returning plain text, a tool can return a <code>ui://</code> resource containing an HTML page that the host sandboxes and displays in the conversation.</p>
+
+  <h2>How it works with mcp-anything</h2>
+  <p>mcp-anything implements the MCP Apps extension so that OpenAPI-generated tools can declare a UI resource. When the host calls the tool, it receives both the structured data and a pointer to an interactive interface:</p>
+  <ol>
+    <li>The tool description includes <code>_meta.ui.resourceUri</code> pointing to a <code>ui://</code> resource registered on the proxy.</li>
+    <li>The host fetches the <code>ui://</code> resource — an HTML page bundled with its CSS and JavaScript.</li>
+    <li>The host renders the HTML in a sandboxed iframe inside the conversation.</li>
+    <li>The app communicates back to the MCP server (and through it to upstream APIs) via postMessage JSON-RPC.</li>
+  </ol>
+
+  <h2>Configuration</h2>
+  <p>Attach a UI resource to any OpenAPI operation via an overlay:</p>
+  <pre><code># overlay.yaml
+- target: "$.paths[\"/analytics/revenue\"].get"
+  update:
+    x-mcp-app:
+      resource: ui://revenue-dashboard    # ui:// resource name
+      source: apps/revenue/index.html     # bundled HTML file to serve</code></pre>
+
+  <p>The proxy registers the HTML file as a <code>ui://revenue-dashboard</code> resource. The tool description is updated automatically to include the <code>_meta.ui.resourceUri</code> field the host expects.</p>
+
+  <h2>Passing tool results to the app</h2>
+  <p>The upstream API response is injected into the app as the initial tool result. Your HTML receives it via the standard MCP Apps <code>ui/initialize</code> message:</p>
+  <pre><code>// Inside your bundled app JavaScript
+import &#123; App &#125; from "@modelcontextprotocol/ext-apps";
+
+const app = new App();
+app.onToolResult((result) => &#123;
+  renderChart(result.content[0].text); // JSON from the upstream API
+&#125;);</code></pre>
+
+  <h2>Calling tools from the app</h2>
+  <p>The app can call any MCP tool on the proxy through the host's postMessage channel — including other OpenAPI tools, shell commands, or scripts:</p>
+  <pre><code>const fresh = await app.callTool("api__get_revenue", &#123;
+  start_date: "2026-01-01",
+  end_date: "2026-03-31",
+  granularity: "monthly",
+&#125;);
+renderChart(JSON.parse(fresh.content[0].text));</code></pre>
+
+  <h2>Content Security Policy</h2>
+  <p>Declare external origins the app needs in the overlay:</p>
+  <pre><code>x-mcp-app:
+  resource: ui://revenue-dashboard
+  source: apps/revenue/index.html
+  csp:
+    script-src:
+      - https://cdn.jsdelivr.net
+    connect-src:
+      - https://fonts.googleapis.com</code></pre>
+
+  <h2>Supported clients</h2>
+  <p>MCP Apps is an <a href="https://modelcontextprotocol.io/extensions/apps/overview" target="_blank" rel="noopener noreferrer">official MCP extension</a>. Hosts that support it include Claude Desktop, Claude (web), VS Code GitHub Copilot, Goose, Postman, and MCPJam. Hosts that do not support the extension ignore the <code>_meta.ui</code> field and display the tool result as plain text — the tool remains fully functional.</p>
+
+  <h2>Use cases</h2>
+  <ul>
+    <li><strong>Data dashboards</strong> — charts and tables that update when the user drills down</li>
+    <li><strong>Configuration forms</strong> — multi-field forms with validation sent back to the upstream API</li>
+    <li><strong>Rich media viewers</strong> — PDF, 3D model, image, or video viewers embedded in the conversation</li>
+    <li><strong>Real-time monitors</strong> — live metric dashboards that poll tools for fresh data</li>
+    <li><strong>Multi-step workflows</strong> — approval queues, code review interfaces, issue triagers</li>
+  </ul>
+
+  <h2>See also</h2>
+  <ul>
+    <li><a href="https://modelcontextprotocol.io/extensions/apps/overview" target="_blank" rel="noopener noreferrer">MCP Apps specification</a></li>
+    <li><a href="/docs/overlays">OpenAPI Overlays</a> — attach <code>x-mcp-app</code> to operations</li>
+    <li><a href="/docs/scripts">JavaScript Scripts</a> — custom tool logic in the same runtime</li>
+    <li><a href="/docs/groups">Tool Groups</a> — scope which tools an app can reach</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -3,111 +3,151 @@ import Layout from '../layouts/Layout.astro';
 
 const features = [
   {
+    num: '01',
+    category: 'Core',
     title: 'OpenAPI Tool Generation',
-    description: 'Auto-generates MCP tools from OpenAPI 3.0 specs with input schemas, jq transforms, and config-time dry-run validation.',
+    description: 'Auto-generates MCP tools from any OpenAPI 3.0 spec. Input schemas are derived automatically, jq transforms applied, and everything validated at startup with dry-run checks.',
+    href: '/docs/openapi',
   },
   {
+    num: '02',
+    category: 'Core',
     title: 'Shell Commands',
-    description: 'Expose kubectl, aws, or any CLI as MCP tools. Template argument interpolation with shell-escape security.',
+    description: 'Expose kubectl, aws, gh, or any CLI as MCP tools. Template-based argument interpolation with shell-escape security — no injection risk.',
+    href: '/docs/commands',
   },
   {
+    num: '03',
+    category: 'Core',
     title: 'JavaScript Scripts',
-    description: 'Custom tools in a sandboxed Sobek runtime with ctx.fetch(), ctx.env, and ctx.log().',
+    description: 'Custom tool logic in a sandboxed Sobek runtime. Full access to ctx.fetch(), ctx.env, and ctx.log() — no Node.js required.',
+    href: '/docs/scripts',
   },
   {
+    num: '04',
+    category: 'Routing',
     title: 'Multi-Upstream Routing',
-    description: 'Proxy HTTP, command, and script backends from one instance. Prefix-based namespacing for uniqueness.',
+    description: 'Proxy multiple HTTP, command, and script backends from a single instance. Prefix-based namespacing ensures tool names never collide across upstreams.',
+    href: '/docs/routing',
   },
   {
-    title: 'Pluggable Auth',
-    description: 'JWT, OAuth2 CC, API key, introspection, Lua, JavaScript. Inbound and outbound. Per-operation bypass.',
+    num: '05',
+    category: 'Auth',
+    title: 'Pluggable Authentication',
+    description: 'JWT, OAuth2 Client Credentials, API key, token introspection, Lua, and JavaScript — both inbound (client → proxy) and outbound (proxy → upstream). Per-operation bypass supported.',
+    href: '/docs/auth',
   },
   {
+    num: '06',
+    category: 'OpenAPI',
     title: 'OpenAPI Overlays',
-    description: 'RFC 9535 JSONPath to customize tool names, descriptions, and behavior without touching specs.',
+    description: 'RFC 9535 JSONPath overlays to customize tool names, descriptions, jq transforms, and behavior without ever touching the original spec.',
+    href: '/docs/overlays',
   },
   {
+    num: '07',
+    category: 'Routing',
     title: 'Tool Groups',
-    description: 'Multiple MCP endpoints with JSONPath filters. Read-only, premium, or admin sets from the same upstreams.',
+    description: 'Serve different tool subsets at different MCP endpoints. JSONPath filters let you create read-only, premium, or role-based views from the same upstreams.',
+    href: '/docs/groups',
   },
   {
+    num: '08',
+    category: 'Operations',
     title: 'Config Hot-Reload',
-    description: 'fsnotify-based live reload. ConfigMap-aware with atomic symlink detection. Zero downtime.',
+    description: 'fsnotify-based live reload with atomic symlink detection — Kubernetes ConfigMap-aware by design. Config changes take effect without dropping any in-flight requests.',
+    href: '/docs/hot-reload',
   },
   {
+    num: '09',
+    category: 'Operations',
+    title: 'Background Spec Refresh',
+    description: 'OpenAPI specs are re-fetched on a configurable interval with ETag/conditional GET support. Updates are swapped in atomically with zero downtime.',
+    href: '/docs/hot-reload',
+  },
+  {
+    num: '10',
+    category: 'Observability',
     title: 'OpenTelemetry',
-    description: 'OTLP traces, Prometheus metrics, W3C propagation, MCP-specific span attributes.',
+    description: 'OTLP traces with MCP-specific span attributes, Prometheus metrics, and W3C Trace Context propagation. Plug into any existing observability stack.',
+    href: '/docs/telemetry',
   },
   {
+    num: '11',
+    category: 'Kubernetes',
     title: 'Kubernetes Operator',
-    description: 'MCPProxy and MCPUpstream CRDs. Annotation-based auto-discovery. Helm chart included.',
+    description: 'MCPProxy and MCPUpstream CRDs for declarative configuration. Annotation-based upstream auto-discovery. Helm chart included.',
+    href: '/docs/kubernetes',
   },
   {
-    title: 'Library-First SDK',
-    description: 'Embed as a Go library. Register custom providers via provider.Provider. Build on top.',
+    num: '12',
+    category: 'SDK',
+    title: 'Library-First Go SDK',
+    description: 'Embed the proxy as a Go library. Register custom tool providers via the registry pattern. Tree-shaking ensures unused strategies are excluded from your binary.',
+    href: '/docs/sdk',
   },
   {
+    num: '13',
+    category: 'Transport',
     title: 'Gateway Transport',
-    description: 'Connection pooling, mTLS, HTTP/2, TLS session caching, SOCKS5 proxy support.',
-  },
-];
-
-const configTabs = [
-  {
-    id: 'http',
-    label: 'HTTP API',
-    code: `upstreams:
-  - name: petstore
-    type: http
-    tool_prefix: pets
-    base_url: https://petstore.example.com/v1
-    openapi:
-      source: https://petstore.example.com/openapi.yaml
-      refresh_interval: 5m
-    outbound_auth:
-      strategy: oauth2_client_credentials
-      oauth2:
-        token_url: https://auth.example.com/token
-        client_id: \${CLIENT_ID}
-        client_secret: \${CLIENT_SECRET}`,
+    description: 'Connection pooling, mTLS, HTTP/2, TLS session caching, and SOCKS5 proxy support for production-grade upstream connectivity.',
+    href: '/docs/transport',
   },
   {
-    id: 'command',
-    label: 'Shell Command',
-    code: `upstreams:
-  - name: cluster
-    type: command
-    tool_prefix: k8s
-    tools:
-      - name: get_pods
-        description: List pods in a namespace
-        command: kubectl get pods -n {{namespace}} -o json
-        args:
-          namespace:
-            type: string
-            description: Kubernetes namespace
-            required: true
-        timeout: 30s`,
+    num: '14',
+    category: 'Reliability',
+    title: 'Rate Limiting',
+    description: 'Token-bucket rate limits per tool, keyed by client IP, authenticated user, or MCP session ID. Burst allowances and per-operation overrides via overlays.',
+    href: '/docs/rate-limiting',
   },
   {
-    id: 'script',
-    label: 'JavaScript',
-    code: `upstreams:
-  - name: custom
-    type: script
-    tool_prefix: ops
-    tools:
-      - name: health_check
-        description: Check service health across regions
-        source: scripts/health_check.js
-        args:
-          service:
-            type: string
-            description: Service name to check
-          regions:
-            type: array
-            description: Regions to query
-        timeout: 10s`,
+    num: '15',
+    category: 'Reliability',
+    title: 'Circuit Breaking',
+    description: 'Per-upstream circuit breaker with configurable failure threshold, rolling window, and half-open probe. Prevents cascading failures when an upstream goes down.',
+    href: '/docs/circuit-breaking',
+  },
+  {
+    num: '16',
+    category: 'Discovery',
+    title: 'Semantic Tool Search',
+    description: 'In-process chromem-go vector index lets MCP clients find the right tool by natural-language description. Supports OpenAI embeddings or a fully local model.',
+    href: '/docs/search',
+  },
+  {
+    num: '17',
+    category: 'Operations',
+    title: 'Tool Result Caching',
+    description: 'TTL-based in-memory cache for tool responses. Per-user isolation when inbound auth is enabled. Automatically invalidated on spec refresh or hot-reload.',
+    href: '/docs/caching',
+  },
+  {
+    num: '18',
+    category: 'Observability',
+    title: 'Token Counting',
+    description: 'Tiktoken-compatible token counting on every tool response before it reaches the MCP client. Histogram metrics per tool and optional hard size limits.',
+    href: '/docs/token-counting',
+  },
+  {
+    num: '19',
+    category: 'Auth',
+    title: 'Per-User OAuth2 Sessions',
+    description: 'Authorization Code flow with per-user token storage in Postgres or Redis. Each user accesses upstream APIs with their own identity — not a shared service account.',
+    href: '/docs/oauth2-sessions',
+  },
+  {
+    num: '20',
+    category: 'Deployment',
+    title: 'Caddy Module',
+    description: 'Embed mcp-anything as a native xcaddy handler. Caddy manages TLS and routing; no separate proxy process. Pre-built Docker image included.',
+    href: '/docs/caddy',
+  },
+  {
+    num: '21',
+    category: 'MCP Apps',
+    title: 'MCP Apps',
+    description: 'Attach interactive HTML interfaces to OpenAPI-generated tools. Results render as sandboxed iframes inside Claude, VS Code, and other MCP hosts — no separate web app needed.',
+    href: '/docs/ui',
   },
 ];
 ---
@@ -116,11 +156,12 @@ const configTabs = [
   title="mcp-anything — Turn anything into MCP tools"
   description="A stateless Go proxy that exposes REST APIs, shell commands, and custom scripts as MCP tools. No code, no plugins — just config."
 >
+<div class="flex flex-col">
   <!-- Nav -->
-  <nav class="sticky top-0 z-50 w-full border-b border-neutral-200 bg-white/80 backdrop-blur-sm dark:border-neutral-800 dark:bg-neutral-950/80">
-    <div class="mx-auto flex h-14 max-w-5xl items-center justify-between px-6">
+  <nav class="flex-none border-b border-neutral-200 bg-white/80 backdrop-blur-sm dark:border-neutral-800 dark:bg-neutral-950/80">
+    <div class="mx-auto flex h-14 max-w-none items-center justify-between px-6 lg:px-8">
       <a href="/" class="flex items-center gap-2.5 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
-        <svg class="h-6 w-6" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg class="h-6 w-6 flex-none" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect width="180" height="180" rx="24" class="fill-neutral-900 dark:fill-neutral-100"/>
           <mask id="nav-m" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="7" y="7" width="166" height="166"><path d="M173 7H7V173H173V7Z" fill="white"/></mask>
           <g mask="url(#nav-m)">
@@ -135,8 +176,7 @@ const configTabs = [
         mcp-anything
       </a>
       <div class="flex items-center gap-5">
-        <a href="#features" class="text-sm text-neutral-500 transition hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100">Features</a>
-        <a href="#config" class="text-sm text-neutral-500 transition hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100">Config</a>
+        <a href="/docs" class="text-sm text-neutral-500 transition hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100">Docs</a>
         <a
           href="https://github.com/gaarutyunov/mcp-anything"
           target="_blank"
@@ -146,185 +186,119 @@ const configTabs = [
           <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
           GitHub
         </a>
-        <!-- Theme toggle -->
         <button
           id="theme-toggle"
           type="button"
           class="flex h-8 w-8 items-center justify-center rounded-md text-neutral-500 transition hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
           aria-label="Toggle theme"
         >
-          <!-- Sun (shown in dark mode) -->
           <svg class="hidden h-4 w-4 dark:block" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"/></svg>
-          <!-- Moon (shown in light mode) -->
           <svg class="block h-4 w-4 dark:hidden" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"/></svg>
         </button>
       </div>
     </div>
   </nav>
 
-  <!-- Hero -->
-  <section class="px-6 pt-20 pb-16 sm:pt-28 sm:pb-20">
-    <div class="mx-auto max-w-2xl text-center">
-      <p class="mb-4 text-sm font-medium text-neutral-500 dark:text-neutral-400">Open source &middot; Apache 2.0</p>
-      <h1 class="mb-4 text-4xl font-bold tracking-tight text-neutral-900 sm:text-5xl dark:text-neutral-100">
-        Turn anything into MCP tools
-      </h1>
-      <p class="mb-8 text-lg text-neutral-500 dark:text-neutral-400">
-        A stateless Go proxy that exposes REST APIs, shell commands, and custom scripts as MCP tools. No code, no plugins — just config.
-      </p>
-      <div class="flex items-center justify-center gap-3">
-        <a
-          href="https://github.com/gaarutyunov/mcp-anything#readme"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center gap-2 rounded-lg bg-neutral-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-neutral-800 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-200"
-        >
-          Get Started
-          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
-        </a>
-        <a
-          href="https://github.com/gaarutyunov/mcp-anything"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex items-center gap-2 rounded-lg border border-neutral-200 px-4 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
-        >
-          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
-          GitHub
-        </a>
-      </div>
-      <div class="mt-8">
-        <div class="inline-flex items-center gap-3 rounded-lg border border-neutral-200 bg-neutral-50 px-4 py-2.5 font-mono text-sm text-neutral-600 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-400">
-          <span class="select-none text-neutral-400 dark:text-neutral-600">$</span>
-          <span>go install github.com/gaarutyunov/mcp-anything/cmd/proxy@latest</span>
-        </div>
-      </div>
-    </div>
-  </section>
+  <!-- Main: two columns on desktop, stacked on mobile -->
+  <div class="flex h-[calc(100vh-114px)] flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">
 
-  <div class="mx-auto max-w-5xl border-t border-neutral-100 dark:border-neutral-800"></div>
-
-  <!-- Provider Types -->
-  <section class="px-6 py-16 sm:py-20">
-    <div class="mx-auto max-w-5xl">
-      <div class="mb-10 text-center">
-        <h2 class="mb-2 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">Three ways to create tools</h2>
-        <p class="text-neutral-500 dark:text-neutral-400">Point at an OpenAPI spec, wrap a CLI command, or write custom JavaScript.</p>
-      </div>
-      <div class="grid gap-4 sm:grid-cols-3">
-        <div class="rounded-lg border border-neutral-200 p-5 transition hover:border-neutral-300 dark:border-neutral-800 dark:hover:border-neutral-700">
-          <div class="mb-3 flex h-8 w-8 items-center justify-center rounded-md bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400">
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5a17.92 17.92 0 0 1-8.716-2.247m0 0A9 9 0 0 1 3 12c0-1.47.353-2.856.978-4.082"/></svg>
-          </div>
-          <h3 class="mb-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">HTTP APIs</h3>
-          <p class="text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">Point at any OpenAPI 3.0 spec. Tools are auto-generated with input schemas, jq transforms, and runtime validation.</p>
-        </div>
-        <div class="rounded-lg border border-neutral-200 p-5 transition hover:border-neutral-300 dark:border-neutral-800 dark:hover:border-neutral-700">
-          <div class="mb-3 flex h-8 w-8 items-center justify-center rounded-md bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400">
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"/></svg>
-          </div>
-          <h3 class="mb-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">Shell Commands</h3>
-          <p class="text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">Wrap kubectl, aws, or any CLI tool. Template-based argument interpolation with shell-escape security.</p>
-        </div>
-        <div class="rounded-lg border border-neutral-200 p-5 transition hover:border-neutral-300 dark:border-neutral-800 dark:hover:border-neutral-700">
-          <div class="mb-3 flex h-8 w-8 items-center justify-center rounded-md bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400">
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"/></svg>
-          </div>
-          <h3 class="mb-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">JavaScript</h3>
-          <p class="text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">Custom logic in a sandboxed Sobek runtime with ctx.fetch(), ctx.env, and ctx.log().</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <div class="mx-auto max-w-5xl border-t border-neutral-100 dark:border-neutral-800"></div>
-
-  <!-- Features -->
-  <section id="features" class="px-6 py-16 sm:py-20">
-    <div class="mx-auto max-w-5xl">
-      <div class="mb-10 text-center">
-        <h2 class="mb-2 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">Production-ready</h2>
-        <p class="text-neutral-500 dark:text-neutral-400">Authentication, observability, hot-reload, and Kubernetes-native deployment.</p>
-      </div>
-      <div class="grid gap-px overflow-hidden rounded-lg border border-neutral-200 bg-neutral-200 sm:grid-cols-2 lg:grid-cols-3 dark:border-neutral-800 dark:bg-neutral-800">
-        {features.map((f) => (
-          <div class="bg-white p-5 dark:bg-neutral-950">
-            <h3 class="mb-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">{f.title}</h3>
-            <p class="text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">{f.description}</p>
-          </div>
-        ))}
-      </div>
-    </div>
-  </section>
-
-  <div class="mx-auto max-w-5xl border-t border-neutral-100 dark:border-neutral-800"></div>
-
-  <!-- Config Examples -->
-  <section id="config" class="px-6 py-16 sm:py-20">
-    <div class="mx-auto max-w-3xl">
-      <div class="mb-10 text-center">
-        <h2 class="mb-2 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">Just config</h2>
-        <p class="text-neutral-500 dark:text-neutral-400">Define upstreams in YAML. The proxy handles everything else.</p>
-      </div>
-      <div class="overflow-hidden rounded-lg border border-neutral-200 dark:border-neutral-800">
-        <div class="flex border-b border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900" id="config-tabs">
-          {configTabs.map((tab, i) => (
-            <button
-              data-tab={tab.id}
-              class:list={[
-                'config-tab px-4 py-2.5 text-xs font-medium transition',
-                i === 0 ? 'text-neutral-900 dark:text-neutral-100 bg-white dark:bg-neutral-950 border-b-2 border-neutral-900 dark:border-neutral-100' : 'text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300',
-              ]}
-            >
-              {tab.label}
-            </button>
-          ))}
-        </div>
-        {configTabs.map((tab, i) => (
-          <div
-            data-panel={tab.id}
-            class:list={['config-panel p-5 bg-white dark:bg-neutral-950', i !== 0 && 'hidden']}
+    <!-- Left: Hero -->
+    <section class="flex flex-1 items-center justify-center px-8 py-8 lg:flex-none lg:w-1/2 lg:justify-end lg:py-0 lg:pr-10">
+      <div class="w-full max-w-lg">
+        <p class="mb-3 text-sm font-medium text-neutral-400 dark:text-neutral-500">Open source &middot; Apache 2.0</p>
+        <h1 class="mb-4 text-4xl font-bold tracking-tight text-neutral-900 sm:text-5xl dark:text-neutral-100">
+          Turn anything<br class="hidden sm:block" /> into MCP tools
+        </h1>
+        <p class="mb-8 text-base leading-relaxed text-neutral-500 dark:text-neutral-400">
+          A stateless Go proxy that exposes REST APIs, shell commands, and custom scripts as MCP tools. No code, no plugins — just config.
+        </p>
+        <div class="flex flex-wrap items-center gap-3">
+          <a
+            href="/docs"
+            class="inline-flex items-center gap-2 rounded-lg bg-neutral-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-neutral-800 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-200"
           >
-            <pre class="overflow-x-auto font-mono text-[13px] leading-relaxed text-neutral-700 dark:text-neutral-300"><code>{tab.code}</code></pre>
+            Get Started
+            <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
+          </a>
+          <a
+            href="https://github.com/gaarutyunov/mcp-anything"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-2 rounded-lg border border-neutral-200 px-4 py-2 text-sm font-medium text-neutral-700 transition hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+          >
+            <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+            GitHub
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Right: Carousel -->
+    <section class="flex flex-1 items-center justify-center px-8 py-8 lg:flex-none lg:w-1/2 lg:justify-start lg:py-0 lg:pl-10">
+      <div class="w-full max-w-lg">
+
+        <!-- Header row: label + ← counter → -->
+        <div class="mb-3 flex items-center justify-between">
+          <p class="text-xs font-semibold uppercase tracking-widest text-neutral-400 dark:text-neutral-500">Features</p>
+          <div class="flex items-center gap-2">
+            <button
+              id="prev-btn"
+              type="button"
+              class="flex h-5 w-5 items-center justify-center text-neutral-400 transition hover:text-neutral-900 dark:text-neutral-500 dark:hover:text-neutral-100"
+              aria-label="Previous feature"
+            >
+              <svg class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/></svg>
+            </button>
+            <p class="font-mono text-xs text-neutral-400 dark:text-neutral-600" id="carousel-counter">01 / 21</p>
+            <button
+              id="next-btn"
+              type="button"
+              class="flex h-5 w-5 items-center justify-center text-neutral-400 transition hover:text-neutral-900 dark:text-neutral-500 dark:hover:text-neutral-100"
+              aria-label="Next feature"
+            >
+              <svg class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+            </button>
           </div>
-        ))}
-      </div>
-    </div>
-  </section>
+        </div>
 
-  <div class="mx-auto max-w-5xl border-t border-neutral-100 dark:border-neutral-800"></div>
+        <!-- Slide track -->
+        <div id="carousel" role="region" aria-label="Feature carousel" aria-live="polite">
+          <div class="relative h-[280px] overflow-hidden rounded-2xl border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950">
+            {features.map((f, i) => (
+              <div
+                data-slide={i}
+                class="carousel-slide absolute inset-0 flex flex-col justify-between p-6 transition-opacity duration-500"
+                style={i === 0 ? 'opacity:1;pointer-events:auto' : 'opacity:0;pointer-events:none'}
+              >
+                <div>
+                  <div class="mb-3 flex items-center gap-2.5">
+                    <span class="font-mono text-xs font-semibold text-neutral-400 dark:text-neutral-500">{f.num}</span>
+                    <span class="rounded-full border border-neutral-200 px-2 py-0.5 text-xs font-medium text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">{f.category}</span>
+                  </div>
+                  <h2 class="mb-2.5 text-lg font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">{f.title}</h2>
+                  <p class="text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">{f.description}</p>
+                </div>
+                <a
+                  href={f.href}
+                  class="inline-flex items-center gap-1.5 text-xs font-medium text-neutral-500 transition hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+                >
+                  Learn more
+                  <svg class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
+                </a>
+              </div>
+            ))}
+          </div>
+        </div>
 
-  <!-- How it works -->
-  <section class="px-6 py-16 sm:py-20">
-    <div class="mx-auto max-w-3xl">
-      <div class="mb-10 text-center">
-        <h2 class="mb-2 text-2xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">How it works</h2>
-        <p class="text-neutral-500 dark:text-neutral-400">A single stateless binary between your MCP clients and your backends.</p>
       </div>
-      <div class="grid gap-4 sm:grid-cols-3">
-        <div class="rounded-lg border border-neutral-200 p-5 text-center dark:border-neutral-800">
-          <div class="mx-auto mb-3 flex h-8 w-8 items-center justify-center rounded-full border border-neutral-200 text-xs font-semibold text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">1</div>
-          <h3 class="mb-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">Define</h3>
-          <p class="text-sm text-neutral-500 dark:text-neutral-400">Point at specs, CLI tools, or scripts in YAML.</p>
-        </div>
-        <div class="rounded-lg border border-neutral-200 p-5 text-center dark:border-neutral-800">
-          <div class="mx-auto mb-3 flex h-8 w-8 items-center justify-center rounded-full border border-neutral-200 text-xs font-semibold text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">2</div>
-          <h3 class="mb-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">Proxy</h3>
-          <p class="text-sm text-neutral-500 dark:text-neutral-400">Tools generated, auth handled, requests validated.</p>
-        </div>
-        <div class="rounded-lg border border-neutral-200 p-5 text-center dark:border-neutral-800">
-          <div class="mx-auto mb-3 flex h-8 w-8 items-center justify-center rounded-full border border-neutral-200 text-xs font-semibold text-neutral-500 dark:border-neutral-700 dark:text-neutral-400">3</div>
-          <h3 class="mb-1 text-sm font-semibold text-neutral-900 dark:text-neutral-100">Connect</h3>
-          <p class="text-sm text-neutral-500 dark:text-neutral-400">Claude, Cursor, or any MCP client uses your tools.</p>
-        </div>
-      </div>
-    </div>
-  </section>
+    </section>
+  </div>
 
   <!-- Footer -->
-  <footer class="border-t border-neutral-200 px-6 py-10 dark:border-neutral-800">
-    <div class="mx-auto flex max-w-5xl flex-col items-center justify-between gap-4 sm:flex-row">
-      <div class="flex items-center gap-2 text-sm text-neutral-500 dark:text-neutral-400">
-        <svg class="h-5 w-5" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <footer class="flex h-14 items-center justify-between border-t border-neutral-200 px-8 dark:border-neutral-800">
+    <div class="flex w-full items-center justify-between">
+      <span class="flex items-center gap-2 text-xs text-neutral-400 dark:text-neutral-500">
+        <svg class="h-4 w-4" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect width="180" height="180" rx="24" class="fill-neutral-900 dark:fill-neutral-100"/>
           <mask id="ft-m" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="7" y="7" width="166" height="166"><path d="M173 7H7V173H173V7Z" fill="white"/></mask>
           <g mask="url(#ft-m)">
@@ -337,48 +311,53 @@ const configTabs = [
           </g>
         </svg>
         mcp-anything
-      </div>
-      <div class="flex items-center gap-5 text-sm text-neutral-400 dark:text-neutral-500">
-        <span>Built with Go</span>
+      </span>
+      <div class="flex items-center gap-4 text-xs text-neutral-400 dark:text-neutral-500">
         <a href="https://github.com/gaarutyunov/mcp-anything/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" class="transition hover:text-neutral-600 dark:hover:text-neutral-300">Apache 2.0</a>
         <a href="https://github.com/gaarutyunov" target="_blank" rel="noopener noreferrer" class="transition hover:text-neutral-600 dark:hover:text-neutral-300">@gaarutyunov</a>
       </div>
     </div>
   </footer>
+</div>
 
   <script>
     // Theme toggle
-    const toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      toggle.addEventListener('click', () => {
-        const isDark = document.documentElement.classList.toggle('dark');
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
-      });
+    document.getElementById('theme-toggle')?.addEventListener('click', () => {
+      const isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    });
+
+    // Carousel state
+    const slides = Array.from(document.querySelectorAll<HTMLElement>('.carousel-slide'));
+    const counter = document.getElementById('carousel-counter');
+    const total = slides.length;
+    let current = 0;
+    let timer: ReturnType<typeof setInterval> | null = null;
+    let paused = false;
+
+    function goTo(index: number) {
+      slides[current].style.opacity = '0';
+      slides[current].style.pointerEvents = 'none';
+      current = (index + total) % total;
+      slides[current].style.opacity = '1';
+      slides[current].style.pointerEvents = 'auto';
+      if (counter) {
+        counter.textContent = `${String(current + 1).padStart(2, '0')} / ${String(total).padStart(2, '0')}`;
+      }
     }
 
-    // Config tabs
-    const tabs = document.querySelectorAll('.config-tab');
-    const panels = document.querySelectorAll('.config-panel');
+    function startTimer() {
+      if (timer) clearInterval(timer);
+      timer = setInterval(() => { if (!paused) goTo(current + 1); }, 4500);
+    }
 
-    tabs.forEach((tab) => {
-      tab.addEventListener('click', () => {
-        const target = (tab as HTMLElement).dataset.tab;
+    document.getElementById('prev-btn')?.addEventListener('click', () => { goTo(current - 1); startTimer(); });
+    document.getElementById('next-btn')?.addEventListener('click', () => { goTo(current + 1); startTimer(); });
 
-        tabs.forEach((t) => {
-          t.classList.remove('text-neutral-900', 'dark:text-neutral-100', 'bg-white', 'dark:bg-neutral-950', 'border-b-2', 'border-neutral-900', 'dark:border-neutral-100');
-          t.classList.add('text-neutral-400');
-        });
-        tab.classList.add('text-neutral-900', 'dark:text-neutral-100', 'bg-white', 'dark:bg-neutral-950', 'border-b-2', 'border-neutral-900', 'dark:border-neutral-100');
-        tab.classList.remove('text-neutral-400');
+    const carousel = document.getElementById('carousel');
+    carousel?.addEventListener('mouseenter', () => { paused = true; });
+    carousel?.addEventListener('mouseleave', () => { paused = false; });
 
-        panels.forEach((p) => {
-          if ((p as HTMLElement).dataset.panel === target) {
-            p.classList.remove('hidden');
-          } else {
-            p.classList.add('hidden');
-          }
-        });
-      });
-    });
+    startTimer();
   </script>
 </Layout>


### PR DESCRIPTION
## Summary

- Expands the homepage feature list from 8 to 21 items with numbered categories and links to new `/docs` pages
- Adds `DocsLayout.astro` and 22 new docs pages covering auth, overlays, SDK, Kubernetes, hot-reload, telemetry, rate limiting, circuit breaking, semantic search, caching, token counting, OAuth2 sessions, Caddy module, and MCP Apps
- Replaces the Petstore placeholder example in README with a real, runnable Kraken market-data example (public API, no key required); updates config snippets and overlay sample throughout
- Minor README wording improvements: double-underscore namespacing note, CRD references, improved auth strategy descriptions

## Test plan

- [ ] Verify website builds without errors (`cd website && npm run build`)
- [ ] Spot-check a few docs pages render correctly in the browser
- [ ] Confirm README links to `deploy/examples/kraken/` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation site covering authentication, caching, circuit breaking, rate limiting, multi-upstream routing, tool groups, deployment on Kubernetes and Caddy, telemetry, OAuth2 sessions, and semantic search.
* **New Features**
  * Redesigned homepage with interactive feature carousel and navigation links to documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->