### PR TITLE
ci: fix helm chart release (remove Pro-only goreleaser section, add helm push step)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,14 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.17.3
+
+      - name: Package and push Helm chart
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          helm package charts/mcp-anything --version "${VERSION}" --app-version "${VERSION}"
+          helm push "mcp-anything-${VERSION}.tgz" oci://ghcr.io/${{ github.repository_owner }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,15 +69,6 @@ dockers_v2:
       - linux/arm64
     dockerfile: Dockerfile.operator.goreleaser
 
-helm_charts:
-  - name: mcp-anything
-    dir: charts/mcp-anything
-    chart_version: "{{ .Version }}"
-    app_version: "{{ .Version }}"
-    oci:
-      - host: ghcr.io
-        owner: gaarutyunov
-
 checksum:
   name_template: "checksums.txt"
 


### PR DESCRIPTION
## Problem

`helm_charts` in `.goreleaser.yml` is a **GoReleaser Pro** feature. The OSS `goreleaser-action` used in the release workflow cannot execute it, so helm charts were never actually published on release.

## Fix

- Remove the `helm_charts` block from `.goreleaser.yml`
- Add explicit `helm package` + `helm push` steps to `release.yml` after GoReleaser runs, using the same pattern already working in `ci.yml` for SHA builds
- Version is derived from the git tag: `GITHUB_REF_NAME` with the leading `v` stripped (`v0.1.0` → `0.1.0`)

## Result

On any `v*` tag push the chart is packaged and pushed to `oci://ghcr.io/gaarutyunov/mcp-anything` with the correct semver, matching the Docker image and binary versions released by GoReleaser in the same job.

## Test plan

- [ ] Push a test tag (`v0.0.1-test`) and verify the chart appears at `ghcr.io/gaarutyunov/mcp-anything:0.0.1-test`
- [ ] Confirm GoReleaser step still succeeds (no Pro license error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)