### PR TITLE
ci: fix goreleaser release errors

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,10 +41,17 @@ builds:
       - arm64
 
 archives:
-  - id: default
+  - id: proxy
+    ids: [proxy]
     formats:
       - tar.gz
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_proxy_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+  - id: operator
+    ids: [operator]
+    formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_operator_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 dockers_v2:
   - id: proxy


### PR DESCRIPTION
## Summary
- Fix duplicate Docker image ID collision between proxy and operator builds
- Split archives by build target to fix "different count of binaries for each platform" error (operator targets linux only, proxy targets linux+darwin)

## Test plan
- [ ] GoReleaser check passes (`goreleaser check`)
- [ ] Release pipeline succeeds on next tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)