### PR TITLE
feat: add command upstream CRD support and remote dev workspace example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,6 @@ jobs:
           file: Dockerfile.operator
           push: true
           tags: ${{ env.OPERATOR_IMAGE }}
-          build-args: PROXY_IMAGE=${{ env.PROXY_IMAGE }}
 
   build-workspace-image:
     name: Build & Push Workspace Image
@@ -159,6 +158,7 @@ jobs:
           file: examples/remote-dev/Dockerfile.workspace
           push: true
           tags: ${{ env.WORKSPACE_IMAGE }}
+          build-args: PROXY_IMAGE=${{ env.PROXY_IMAGE }}
 
   integration-test:
     name: Integration Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
   e2e-tests:
     name: E2E / ${{ matrix.name }}
     runs-on: ubuntu-latest
-    needs: [build-image, build-operator-image]
+    needs: [build-image, build-operator-image, build-workspace-image]
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
           file: Dockerfile.operator
           push: true
           tags: ${{ env.OPERATOR_IMAGE }}
+          build-args: PROXY_IMAGE=${{ env.PROXY_IMAGE }}
 
   build-workspace-image:
     name: Build & Push Workspace Image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
   build-workspace-image:
     name: Build & Push Workspace Image
     runs-on: ubuntu-latest
+    needs: [build-image]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ env:
   OPERATOR_IMAGE: ghcr.io/${{ github.repository }}-operator:sha-${{ github.sha }}
   PROXY_IMAGE: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
   CADDY_IMAGE: ghcr.io/${{ github.repository }}-caddy:sha-${{ github.sha }}
+  WORKSPACE_IMAGE: ghcr.io/${{ github.repository }}-workspace:sha-${{ github.sha }}
 
 jobs:
   lint-and-test:
@@ -134,6 +135,30 @@ jobs:
           push: true
           tags: ${{ env.OPERATOR_IMAGE }}
 
+  build-workspace-image:
+    name: Build & Push Workspace Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: examples/remote-dev/Dockerfile.operator
+          push: true
+          tags: ${{ env.WORKSPACE_IMAGE }}
+
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
@@ -168,6 +193,8 @@ jobs:
         include:
           - name: Kraken Market Data
             test: TestKrakenMarketDataE2E
+          - name: Remote Dev Workspace
+            test: TestRemoteDevWorkspaceE2E
     steps:
       - uses: actions/checkout@v4
 
@@ -187,3 +214,4 @@ jobs:
           PROXY_IMAGE: ${{ env.PROXY_IMAGE }}
           OPERATOR_IMAGE: ${{ env.OPERATOR_IMAGE }}
           E2E_TEST: ${{ matrix.test }}
+          WORKSPACE_IMAGE: ${{ env.WORKSPACE_IMAGE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: examples/remote-dev/Dockerfile.operator
+          file: examples/remote-dev/Dockerfile.workspace
           push: true
           tags: ${{ env.WORKSPACE_IMAGE }}
 

--- a/cmd/testhelpers/write-file/main.go
+++ b/cmd/testhelpers/write-file/main.go
@@ -1,0 +1,95 @@
+// Command write-file writes content to a file safely.
+// It validates the target path is under the workspace root to prevent
+// directory traversal attacks, creates parent directories as needed,
+// and writes content atomically via a temporary file and rename.
+//
+// Usage: write-file <path> <content>
+//
+// The workspace root defaults to /workspace and can be overridden with
+// the WORKSPACE_ROOT environment variable.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "usage: write-file <path> <content>\n")
+		os.Exit(1)
+	}
+
+	targetPath := os.Args[1]
+	content := os.Args[2]
+
+	workspaceRoot := os.Getenv("WORKSPACE_ROOT")
+	if workspaceRoot == "" {
+		workspaceRoot = "/workspace"
+	}
+
+	if err := writeFile(workspaceRoot, targetPath, content); err != nil {
+		fmt.Fprintf(os.Stderr, "write-file: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// writeFile validates that targetPath is under workspaceRoot and writes content to it atomically.
+func writeFile(workspaceRoot, targetPath, content string) error {
+	// Resolve workspace root to an absolute, clean path.
+	absRoot, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return fmt.Errorf("resolving workspace root %q: %w", workspaceRoot, err)
+	}
+
+	// Resolve the target path. If it is relative, treat it as relative to the workspace root.
+	var absTarget string
+	if filepath.IsAbs(targetPath) {
+		absTarget = filepath.Clean(targetPath)
+	} else {
+		absTarget = filepath.Clean(filepath.Join(absRoot, targetPath))
+	}
+
+	// Ensure the target is under the workspace root.
+	if !strings.HasPrefix(absTarget+string(filepath.Separator), absRoot+string(filepath.Separator)) {
+		return fmt.Errorf("path %q is outside workspace root %q", targetPath, workspaceRoot)
+	}
+
+	// Create parent directories.
+	if err := os.MkdirAll(filepath.Dir(absTarget), 0o755); err != nil {
+		return fmt.Errorf("creating parent directories for %q: %w", absTarget, err)
+	}
+
+	// Write atomically: write to temp file in same directory, then rename.
+	dir := filepath.Dir(absTarget)
+	tmpFile, err := os.CreateTemp(dir, ".write-file-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file in %q: %w", dir, err)
+	}
+	tmpName := tmpFile.Name()
+
+	// Clean up temp file on failure.
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("writing content to temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpName, absTarget); err != nil {
+		return fmt.Errorf("renaming temp file to %q: %w", absTarget, err)
+	}
+
+	success = true
+	return nil
+}

--- a/deploy/helm/mcp-anything/crds/mcpupstream.yaml
+++ b/deploy/helm/mcp-anything/crds/mcpupstream.yaml
@@ -32,11 +32,68 @@ spec:
             spec:
               type: object
               description: MCPUpstreamSpec defines the desired state of MCPUpstream.
-              required: [openapi]
               properties:
+                type:
+                  type: string
+                  description: "Type is the upstream type: http (default) or command."
+                  default: http
+                  enum: [http, command]
                 toolPrefix:
                   type: string
                   description: ToolPrefix is prepended to all tool names from this upstream.
+                commands:
+                  type: array
+                  description: Commands defines command-backed MCP tools. Required when type is command.
+                  items:
+                    type: object
+                    required: [toolName, command]
+                    properties:
+                      toolName:
+                        type: string
+                        description: ToolName is the tool name (without prefix).
+                      description:
+                        type: string
+                        description: Description is the human-readable tool description.
+                      command:
+                        type: string
+                        description: Command is the Go text/template command string.
+                      shell:
+                        type: boolean
+                        description: Shell enables shell mode (sh -c) with auto-quoting.
+                      workingDir:
+                        type: string
+                        description: WorkingDir sets the working directory for the child process.
+                      timeout:
+                        type: string
+                        description: "Timeout per execution (e.g. 30s)."
+                      maxOutput:
+                        type: integer
+                        format: int64
+                        description: MaxOutput caps bytes captured from stdout/stderr.
+                      env:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: Env is a map of additional environment variables.
+                      inputSchema:
+                        type: object
+                        description: InputSchema defines the JSON Schema for tool arguments.
+                        properties:
+                          type:
+                            type: string
+                          properties:
+                            type: object
+                            additionalProperties:
+                              type: object
+                              properties:
+                                type:
+                                  type: string
+                                description:
+                                  type: string
+                          required:
+                            type: array
+                            items:
+                              type: string
                 serviceRef:
                   type: object
                   description: ServiceRef references an in-cluster Kubernetes Service.

--- a/examples/remote-dev/Dockerfile.workspace
+++ b/examples/remote-dev/Dockerfile.workspace
@@ -12,6 +12,10 @@
 
 ARG GO_VERSION=1.24
 ARG GOLANGCI_LINT_VERSION=v1.64.0
+ARG PROXY_IMAGE=mcp-anything:latest
+
+# ── Stage 0: extract proxy binary from proxy image ───────────────────────────
+FROM ${PROXY_IMAGE} AS proxy-binary
 
 # ── Stage 1: build write-file helper ─────────────────────────────────────────
 FROM golang:${GO_VERSION}-alpine AS helper-builder
@@ -35,9 +39,8 @@ RUN wget -q -O- "https://raw.githubusercontent.com/golangci/golangci-lint/master
 # Copy write-file helper from builder stage
 COPY --from=helper-builder /usr/local/bin/write-file /usr/local/bin/write-file
 
-# Copy the proxy binary (must be provided via --build-arg PROXY_IMAGE or copied externally)
-# When building for E2E tests, the proxy binary is copied from the proxy image.
-COPY bin/proxy /usr/local/bin/proxy
+# Copy the proxy binary from the proxy image (/usr/local/bin/proxy per Dockerfile)
+COPY --from=proxy-binary /usr/local/bin/proxy /usr/local/bin/proxy
 
 # Seed the workspace with the sample project
 WORKDIR /workspace

--- a/examples/remote-dev/Dockerfile.workspace
+++ b/examples/remote-dev/Dockerfile.workspace
@@ -10,7 +10,7 @@
 #     --build-arg PROXY_IMAGE=<proxy-image> \
 #     -t workspace:latest .
 
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 ARG GOLANGCI_LINT_VERSION=v1.64.0
 ARG PROXY_IMAGE=mcp-anything:latest
 

--- a/examples/remote-dev/Dockerfile.workspace
+++ b/examples/remote-dev/Dockerfile.workspace
@@ -11,7 +11,7 @@
 #     -t workspace:latest .
 
 ARG GO_VERSION=1.25
-ARG GOLANGCI_LINT_VERSION=v1.64.0
+ARG GOLANGCI_LINT_VERSION=v2.7.2
 ARG PROXY_IMAGE=mcp-anything:latest
 
 # ── Stage 0: extract proxy binary from proxy image ───────────────────────────

--- a/examples/remote-dev/Dockerfile.workspace
+++ b/examples/remote-dev/Dockerfile.workspace
@@ -1,0 +1,54 @@
+# Dockerfile.workspace builds a remote development workspace image that combines:
+#   - mcp-anything proxy binary
+#   - Go toolchain
+#   - golangci-lint
+#   - write-file helper (safe atomic file writer)
+#   - sample Go project pre-seeded in /workspace
+#
+# Build from the repo root:
+#   docker build -f examples/remote-dev/Dockerfile.workspace \
+#     --build-arg PROXY_IMAGE=<proxy-image> \
+#     -t workspace:latest .
+
+ARG GO_VERSION=1.24
+ARG GOLANGCI_LINT_VERSION=v1.64.0
+
+# ── Stage 1: build write-file helper ─────────────────────────────────────────
+FROM golang:${GO_VERSION}-alpine AS helper-builder
+WORKDIR /build
+COPY go.mod go.sum ./
+COPY cmd/testhelpers/write-file/ ./cmd/testhelpers/write-file/
+RUN CGO_ENABLED=0 go build -trimpath -o /usr/local/bin/write-file ./cmd/testhelpers/write-file/
+
+# ── Stage 2: final workspace image ───────────────────────────────────────────
+FROM golang:${GO_VERSION}-alpine
+
+ARG GOLANGCI_LINT_VERSION
+
+# Install required tools
+RUN apk add --no-cache git bash grep findutils
+
+# Install golangci-lint
+RUN wget -q -O- "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh" \
+    | sh -s -- -b /usr/local/bin "${GOLANGCI_LINT_VERSION}"
+
+# Copy write-file helper from builder stage
+COPY --from=helper-builder /usr/local/bin/write-file /usr/local/bin/write-file
+
+# Copy the proxy binary (must be provided via --build-arg PROXY_IMAGE or copied externally)
+# When building for E2E tests, the proxy binary is copied from the proxy image.
+COPY bin/proxy /usr/local/bin/proxy
+
+# Seed the workspace with the sample project
+WORKDIR /workspace
+COPY examples/remote-dev/sample-project/ ./
+
+# Pre-download Go module dependencies
+RUN go mod download
+
+# Warm up golangci-lint cache (optional but speeds up first run)
+RUN golangci-lint run ./... || true
+
+EXPOSE 8080
+ENV CONFIG_PATH=/etc/mcp-anything/config.yaml
+ENTRYPOINT ["/usr/local/bin/proxy"]

--- a/examples/remote-dev/config.yaml
+++ b/examples/remote-dev/config.yaml
@@ -1,0 +1,94 @@
+server:
+  port: 8080
+
+naming:
+  separator: "__"
+
+upstreams:
+  - name: dev
+    enabled: true
+    tool_prefix: dev
+    type: command
+    commands:
+      - tool_name: write_file
+        description: "Write content to a file in the workspace"
+        command: "/usr/local/bin/write-file {{.path}} {{.content}}"
+        timeout: 10s
+        input_schema:
+          type: object
+          properties:
+            path:
+              type: string
+              description: "File path relative to /workspace (or absolute path under /workspace)"
+            content:
+              type: string
+              description: "File content to write"
+          required: [path, content]
+
+      - tool_name: read_file
+        description: "Read the contents of a file"
+        command: "cat {{.path}}"
+        timeout: 10s
+        input_schema:
+          type: object
+          properties:
+            path:
+              type: string
+              description: "Absolute file path to read"
+          required: [path]
+
+      - tool_name: list_files
+        description: "List files matching a pattern in a directory"
+        command: "find {{.directory}} -type f -name {{.pattern}}"
+        timeout: 10s
+        input_schema:
+          type: object
+          properties:
+            directory:
+              type: string
+              description: "Directory to search in"
+            pattern:
+              type: string
+              description: "File name glob pattern (e.g. *.go)"
+          required: [directory, pattern]
+
+      - tool_name: search_files
+        description: "Search file contents for a pattern (grep)"
+        command: "grep -rn {{.pattern}} {{.directory}}"
+        timeout: 30s
+        input_schema:
+          type: object
+          properties:
+            pattern:
+              type: string
+              description: "Search pattern (fixed string or regex)"
+            directory:
+              type: string
+              description: "Directory to search in"
+          required: [pattern, directory]
+
+      - tool_name: run_lint
+        description: "Run Go linter and return diagnostics"
+        command: "golangci-lint run {{.path}}"
+        working_dir: /workspace
+        timeout: 60s
+        input_schema:
+          type: object
+          properties:
+            path:
+              type: string
+              description: "Package path to lint (e.g. ./...)"
+          required: [path]
+
+      - tool_name: run_build
+        description: "Run Go build and return errors"
+        command: "go build {{.path}}"
+        working_dir: /workspace
+        timeout: 60s
+        input_schema:
+          type: object
+          properties:
+            path:
+              type: string
+              description: "Package path to build (e.g. ./...)"
+          required: [path]

--- a/examples/remote-dev/mcpproxy.yaml
+++ b/examples/remote-dev/mcpproxy.yaml
@@ -1,0 +1,14 @@
+apiVersion: mcp-anything.ai/v1alpha1
+kind: MCPProxy
+metadata:
+  name: remote-dev-proxy
+  namespace: remote-dev-e2e
+spec:
+  upstreamSelector:
+    matchLabels:
+      mcp-anything.ai/proxy: remote-dev-proxy
+  # image: <workspace-image>  # Custom image with Go + golangci-lint + write-file helper
+  server:
+    port: 8080
+  naming:
+    separator: "__"

--- a/examples/remote-dev/mcpupstream.yaml
+++ b/examples/remote-dev/mcpupstream.yaml
@@ -1,0 +1,93 @@
+apiVersion: mcp-anything.ai/v1alpha1
+kind: MCPUpstream
+metadata:
+  name: remote-dev
+  namespace: remote-dev-e2e
+  labels:
+    mcp-anything.ai/proxy: remote-dev-proxy
+spec:
+  type: command
+  toolPrefix: dev
+  commands:
+    - toolName: write_file
+      description: "Write content to a file in the workspace"
+      command: "/usr/local/bin/write-file {{.path}} {{.content}}"
+      timeout: "10s"
+      inputSchema:
+        type: object
+        properties:
+          path:
+            type: string
+            description: "File path relative to /workspace (or absolute path under /workspace)"
+          content:
+            type: string
+            description: "File content to write"
+        required: [path, content]
+
+    - toolName: read_file
+      description: "Read the contents of a file"
+      command: "cat {{.path}}"
+      timeout: "10s"
+      inputSchema:
+        type: object
+        properties:
+          path:
+            type: string
+            description: "Absolute file path to read"
+        required: [path]
+
+    - toolName: list_files
+      description: "List files matching a pattern in a directory"
+      command: "find {{.directory}} -type f -name {{.pattern}}"
+      timeout: "10s"
+      inputSchema:
+        type: object
+        properties:
+          directory:
+            type: string
+            description: "Directory to search in"
+          pattern:
+            type: string
+            description: "File name glob pattern (e.g. *.go)"
+        required: [directory, pattern]
+
+    - toolName: search_files
+      description: "Search file contents for a pattern (grep)"
+      command: "grep -rn {{.pattern}} {{.directory}}"
+      timeout: "30s"
+      inputSchema:
+        type: object
+        properties:
+          pattern:
+            type: string
+            description: "Search pattern (fixed string or regex)"
+          directory:
+            type: string
+            description: "Directory to search in"
+        required: [pattern, directory]
+
+    - toolName: run_lint
+      description: "Run Go linter and return diagnostics"
+      command: "golangci-lint run {{.path}}"
+      workingDir: /workspace
+      timeout: "60s"
+      inputSchema:
+        type: object
+        properties:
+          path:
+            type: string
+            description: "Package path to lint (e.g. ./...)"
+        required: [path]
+
+    - toolName: run_build
+      description: "Run Go build and return errors"
+      command: "go build {{.path}}"
+      workingDir: /workspace
+      timeout: "60s"
+      inputSchema:
+        type: object
+        properties:
+          path:
+            type: string
+            description: "Package path to build (e.g. ./...)"
+        required: [path]

--- a/examples/remote-dev/sample-project/.golangci.yml
+++ b/examples/remote-dev/sample-project/.golangci.yml
@@ -1,0 +1,11 @@
+version: "2"
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/examples/remote-dev/sample-project/go.mod
+++ b/examples/remote-dev/sample-project/go.mod
@@ -1,0 +1,3 @@
+module example.com/workspace
+
+go 1.23

--- a/examples/remote-dev/sample-project/main.go
+++ b/examples/remote-dev/sample-project/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	os.Remove("/tmp/mcp-test-cleanup") // errcheck: result of os.Remove should be checked
+	fmt.Println("Hello, workspace!")
+}

--- a/pkg/crd/v1alpha1/types.go
+++ b/pkg/crd/v1alpha1/types.go
@@ -197,22 +197,31 @@ type MCPUpstream struct {
 
 // MCPUpstreamSpec defines the desired state of MCPUpstream.
 type MCPUpstreamSpec struct {
+	// Type is the upstream type: "http" (default) or "command".
+	// HTTP upstreams require baseURL/serviceRef and openapi.
+	// Command upstreams require commands and must not set baseURL/serviceRef/openapi.
+	// +optional
+	// +kubebuilder:default=http
+	// +kubebuilder:validation:Enum=http;command
+	Type string `json:"type,omitempty"`
+
 	// ToolPrefix is prepended to all tool names from this upstream.
 	// +optional
 	ToolPrefix string `json:"toolPrefix,omitempty"`
 
 	// ServiceRef references an in-cluster Kubernetes Service.
-	// Mutually exclusive with BaseURL.
+	// Mutually exclusive with BaseURL. Only used when Type is "http".
 	// +optional
 	ServiceRef *ServiceRefSpec `json:"serviceRef,omitempty"`
 
 	// BaseURL is the base URL for the upstream HTTP API.
-	// Mutually exclusive with ServiceRef.
+	// Mutually exclusive with ServiceRef. Only used when Type is "http".
 	// +optional
 	BaseURL string `json:"baseURL,omitempty"`
 
-	// OpenAPI configures the OpenAPI spec source.
-	OpenAPI MCPUpstreamOpenAPISpec `json:"openapi"`
+	// OpenAPI configures the OpenAPI spec source. Required when Type is "http".
+	// +optional
+	OpenAPI MCPUpstreamOpenAPISpec `json:"openapi,omitempty"`
 
 	// Overlay configures an optional OpenAPI Overlay document.
 	// +optional
@@ -229,6 +238,73 @@ type MCPUpstreamSpec struct {
 	// Validation configures request/response validation against the OpenAPI schema.
 	// +optional
 	Validation *MCPUpstreamValidationSpec `json:"validation,omitempty"`
+
+	// Commands defines command-backed MCP tools. Required when Type is "command".
+	// +optional
+	Commands []MCPUpstreamCommandSpec `json:"commands,omitempty"`
+}
+
+// MCPUpstreamCommandSpec defines a single command-backed MCP tool in the CRD.
+type MCPUpstreamCommandSpec struct {
+	// ToolName is the tool name (without prefix).
+	ToolName string `json:"toolName"`
+
+	// Description is the human-readable tool description.
+	// +optional
+	Description string `json:"description,omitempty"`
+
+	// Command is the Go text/template command string.
+	Command string `json:"command"`
+
+	// Shell enables shell mode (sh -c) with auto-quoting. Default false.
+	// +optional
+	Shell bool `json:"shell,omitempty"`
+
+	// WorkingDir sets the working directory for the child process.
+	// +optional
+	WorkingDir string `json:"workingDir,omitempty"`
+
+	// Timeout per execution (e.g. "30s").
+	// +optional
+	Timeout string `json:"timeout,omitempty"`
+
+	// MaxOutput caps bytes captured from stdout/stderr. 0 = 1 MiB default.
+	// +optional
+	MaxOutput int64 `json:"maxOutput,omitempty"`
+
+	// Env is a map of additional environment variables.
+	// +optional
+	Env map[string]string `json:"env,omitempty"`
+
+	// InputSchema defines the JSON Schema for tool arguments.
+	// +optional
+	InputSchema *MCPUpstreamCommandInputSchema `json:"inputSchema,omitempty"`
+}
+
+// MCPUpstreamCommandInputSchema is the JSON Schema for a command tool's input.
+type MCPUpstreamCommandInputSchema struct {
+	// Type is the JSON Schema type (default "object").
+	// +optional
+	Type string `json:"type,omitempty"`
+
+	// Properties defines the schema properties.
+	// +optional
+	Properties map[string]MCPUpstreamCommandSchemaProperty `json:"properties,omitempty"`
+
+	// Required lists required property names.
+	// +optional
+	Required []string `json:"required,omitempty"`
+}
+
+// MCPUpstreamCommandSchemaProperty describes a single property in a command input schema.
+type MCPUpstreamCommandSchemaProperty struct {
+	// Type is the JSON Schema type.
+	// +optional
+	Type string `json:"type,omitempty"`
+
+	// Description is the human-readable description.
+	// +optional
+	Description string `json:"description,omitempty"`
 }
 
 // ServiceRefSpec references a Kubernetes Service.

--- a/pkg/crd/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/crd/v1alpha1/zz_generated.deepcopy.go
@@ -186,6 +186,82 @@ func (in *MCPUpstreamSpec) DeepCopyInto(out *MCPUpstreamSpec) {
 		*out = new(MCPUpstreamValidationSpec)
 		**out = **in
 	}
+	if in.Commands != nil {
+		in, out := &in.Commands, &out.Commands
+		*out = make([]MCPUpstreamCommandSpec, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+// DeepCopyInto copies all properties of MCPUpstreamCommandSpec into another object.
+func (in *MCPUpstreamCommandSpec) DeepCopyInto(out *MCPUpstreamCommandSpec) {
+	*out = *in
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.InputSchema != nil {
+		in, out := &in.InputSchema, &out.InputSchema
+		*out = new(MCPUpstreamCommandInputSchema)
+		(*in).DeepCopyInto(*out)
+	}
+}
+
+// DeepCopy creates a deep copy of MCPUpstreamCommandSpec.
+func (in *MCPUpstreamCommandSpec) DeepCopy() *MCPUpstreamCommandSpec {
+	if in == nil {
+		return nil
+	}
+	out := new(MCPUpstreamCommandSpec)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto copies all properties of MCPUpstreamCommandInputSchema into another object.
+func (in *MCPUpstreamCommandInputSchema) DeepCopyInto(out *MCPUpstreamCommandInputSchema) {
+	*out = *in
+	if in.Properties != nil {
+		in, out := &in.Properties, &out.Properties
+		*out = make(map[string]MCPUpstreamCommandSchemaProperty, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Required != nil {
+		in, out := &in.Required, &out.Required
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+}
+
+// DeepCopy creates a deep copy of MCPUpstreamCommandInputSchema.
+func (in *MCPUpstreamCommandInputSchema) DeepCopy() *MCPUpstreamCommandInputSchema {
+	if in == nil {
+		return nil
+	}
+	out := new(MCPUpstreamCommandInputSchema)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto copies all properties of MCPUpstreamCommandSchemaProperty into another object.
+func (in *MCPUpstreamCommandSchemaProperty) DeepCopyInto(out *MCPUpstreamCommandSchemaProperty) {
+	*out = *in
+}
+
+// DeepCopy creates a deep copy of MCPUpstreamCommandSchemaProperty.
+func (in *MCPUpstreamCommandSchemaProperty) DeepCopy() *MCPUpstreamCommandSchemaProperty {
+	if in == nil {
+		return nil
+	}
+	out := new(MCPUpstreamCommandSchemaProperty)
+	in.DeepCopyInto(out)
+	return out
 }
 
 // DeepCopy creates a deep copy of MCPUpstreamSpec.

--- a/pkg/operator/configgen/generator.go
+++ b/pkg/operator/configgen/generator.go
@@ -56,16 +56,41 @@ type generatedUpstreamConfig struct {
 	Name         string                     `yaml:"name"`
 	Enabled      bool                       `yaml:"enabled"`
 	ToolPrefix   string                     `yaml:"tool_prefix,omitempty"`
+	Type         string                     `yaml:"type,omitempty"`
 	BaseURL      string                     `yaml:"base_url,omitempty"`
-	OpenAPI      generatedOpenAPIConfig     `yaml:"openapi"`
+	OpenAPI      *generatedOpenAPIConfig    `yaml:"openapi,omitempty"`
 	Overlay      *generatedOverlayConfig    `yaml:"overlay,omitempty"`
 	OutboundAuth *generatedOutboundAuth     `yaml:"outbound_auth,omitempty"`
 	Transport    *generatedTransportConfig  `yaml:"transport,omitempty"`
 	Validation   *generatedValidationConfig `yaml:"validation,omitempty"`
+	Commands     []generatedCommandConfig   `yaml:"commands,omitempty"`
 }
 
 type generatedOpenAPIConfig struct {
 	Source string `yaml:"source"`
+}
+
+type generatedCommandConfig struct {
+	ToolName    string                       `yaml:"tool_name"`
+	Description string                       `yaml:"description,omitempty"`
+	Command     string                       `yaml:"command"`
+	Shell       bool                         `yaml:"shell,omitempty"`
+	WorkingDir  string                       `yaml:"working_dir,omitempty"`
+	Timeout     string                       `yaml:"timeout,omitempty"`
+	MaxOutput   int64                        `yaml:"max_output,omitempty"`
+	Env         map[string]string            `yaml:"env,omitempty"`
+	InputSchema *generatedCommandInputSchema `yaml:"input_schema,omitempty"`
+}
+
+type generatedCommandInputSchema struct {
+	Type       string                                    `yaml:"type,omitempty"`
+	Properties map[string]generatedCommandSchemaProperty `yaml:"properties,omitempty"`
+	Required   []string                                  `yaml:"required,omitempty"`
+}
+
+type generatedCommandSchemaProperty struct {
+	Type        string `yaml:"type,omitempty"`
+	Description string `yaml:"description,omitempty"`
 }
 
 type generatedOverlayConfig struct {
@@ -168,6 +193,68 @@ func buildUpstreamConfig(up *v1alpha1.MCPUpstream) (generatedUpstreamConfig, err
 		ToolPrefix: up.Spec.ToolPrefix,
 	}
 
+	// Dispatch by upstream type.
+	upstreamType := up.Spec.Type
+	if upstreamType == "" {
+		upstreamType = "http"
+	}
+
+	switch upstreamType {
+	case "command":
+		return buildCommandUpstreamConfig(up, uc)
+	default:
+		return buildHTTPUpstreamConfig(up, uc)
+	}
+}
+
+// buildCommandUpstreamConfig fills in a generatedUpstreamConfig for a command upstream.
+func buildCommandUpstreamConfig(up *v1alpha1.MCPUpstream, uc generatedUpstreamConfig) (generatedUpstreamConfig, error) {
+	if len(up.Spec.Commands) == 0 {
+		return generatedUpstreamConfig{}, fmt.Errorf("upstream %s/%s: type command requires at least one command entry", up.Namespace, up.Name)
+	}
+
+	uc.Type = "command"
+	cmds := make([]generatedCommandConfig, 0, len(up.Spec.Commands))
+	for _, cmd := range up.Spec.Commands {
+		gc := generatedCommandConfig{
+			ToolName:    cmd.ToolName,
+			Description: cmd.Description,
+			Command:     cmd.Command,
+			Shell:       cmd.Shell,
+			WorkingDir:  cmd.WorkingDir,
+			Timeout:     cmd.Timeout,
+			MaxOutput:   cmd.MaxOutput,
+			Env:         cmd.Env,
+		}
+		if cmd.InputSchema != nil {
+			gc.InputSchema = buildGeneratedInputSchema(cmd.InputSchema)
+		}
+		cmds = append(cmds, gc)
+	}
+	uc.Commands = cmds
+	return uc, nil
+}
+
+// buildGeneratedInputSchema converts an MCPUpstreamCommandInputSchema to its generated form.
+func buildGeneratedInputSchema(s *v1alpha1.MCPUpstreamCommandInputSchema) *generatedCommandInputSchema {
+	gs := &generatedCommandInputSchema{
+		Type:     s.Type,
+		Required: s.Required,
+	}
+	if len(s.Properties) > 0 {
+		gs.Properties = make(map[string]generatedCommandSchemaProperty, len(s.Properties))
+		for name, prop := range s.Properties {
+			gs.Properties[name] = generatedCommandSchemaProperty{
+				Type:        prop.Type,
+				Description: prop.Description,
+			}
+		}
+	}
+	return gs
+}
+
+// buildHTTPUpstreamConfig fills in a generatedUpstreamConfig for an HTTP upstream.
+func buildHTTPUpstreamConfig(up *v1alpha1.MCPUpstream, uc generatedUpstreamConfig) (generatedUpstreamConfig, error) {
 	// Base URL resolution.
 	switch {
 	case up.Spec.ServiceRef != nil:
@@ -186,11 +273,11 @@ func buildUpstreamConfig(up *v1alpha1.MCPUpstream) (generatedUpstreamConfig, err
 	openAPI := up.Spec.OpenAPI
 	switch {
 	case openAPI.ConfigMapRef != nil:
-		uc.OpenAPI = generatedOpenAPIConfig{
+		uc.OpenAPI = &generatedOpenAPIConfig{
 			Source: fmt.Sprintf("%s/%s_%s.yaml", specsDir, up.Namespace, up.Name),
 		}
 	case openAPI.URL != "":
-		uc.OpenAPI = generatedOpenAPIConfig{
+		uc.OpenAPI = &generatedOpenAPIConfig{
 			Source: openAPI.URL,
 		}
 	case openAPI.AutoDiscover != nil:
@@ -198,7 +285,7 @@ func buildUpstreamConfig(up *v1alpha1.MCPUpstream) (generatedUpstreamConfig, err
 		if path == "" {
 			path = "/openapi.json"
 		}
-		uc.OpenAPI = generatedOpenAPIConfig{
+		uc.OpenAPI = &generatedOpenAPIConfig{
 			Source: uc.BaseURL + path,
 		}
 	default:

--- a/pkg/operator/controller/mcpproxy_controller.go
+++ b/pkg/operator/controller/mcpproxy_controller.go
@@ -193,9 +193,13 @@ func (r *MCPProxyReconciler) reconcileConfigMap(ctx context.Context, proxy *v1al
 
 // reconcileUpstreamConfigMaps copies OpenAPI spec and overlay data from source ConfigMaps
 // (potentially in other namespaces) into local ConfigMaps mounted by the proxy pod.
+// Command upstreams (type: command) do not use spec or overlay ConfigMaps and are skipped.
 func (r *MCPProxyReconciler) reconcileUpstreamConfigMaps(ctx context.Context, proxy *v1alpha1.MCPProxy, upstreams []v1alpha1.MCPUpstream) error {
 	for i := range upstreams {
 		up := &upstreams[i]
+		if up.Spec.Type == "command" {
+			continue
+		}
 		if err := r.reconcileUpstreamSpecCM(ctx, proxy, up); err != nil {
 			return err
 		}
@@ -355,10 +359,14 @@ func (r *MCPProxyReconciler) buildDeployment(proxy *v1alpha1.MCPProxy, upstreams
 		},
 	}
 
-	// Add specs volume if any upstream uses a configMapRef for OpenAPI.
+	// Add specs volume if any HTTP upstream uses a configMapRef for OpenAPI.
+	// Command upstreams (type: command) never use spec or overlay ConfigMaps.
 	hasSpecs := false
 	hasOverlays := false
 	for i := range upstreams {
+		if upstreams[i].Spec.Type == "command" {
+			continue
+		}
 		if upstreams[i].Spec.OpenAPI.ConfigMapRef != nil {
 			hasSpecs = true
 		}

--- a/tests/e2e/remote_dev_e2e_test.go
+++ b/tests/e2e/remote_dev_e2e_test.go
@@ -1,0 +1,542 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/gaarutyunov/mcp-anything/pkg/crd/v1alpha1"
+)
+
+const (
+	remoteDevNamespace  = "remote-dev-e2e"
+	remoteDevProxyName  = "remote-dev-proxy"
+	remoteDevUpstream   = "remote-dev"
+	remoteDevProxyPort  = 8080
+
+	// mainGoWithLintIssue is the initial workspace main.go that contains a deliberate
+	// errcheck lint violation: the result of os.Remove is not checked.
+	mainGoWithLintIssue = `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	os.Remove("/tmp/mcp-test-cleanup") // errcheck: result of os.Remove should be checked
+	fmt.Println("Hello, workspace!")
+}
+`
+
+	// mainGoFixed replaces the unchecked os.Remove with a properly handled error.
+	mainGoFixed = `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if err := os.Remove("/tmp/mcp-test-cleanup"); err != nil && !os.IsNotExist(err) {
+		fmt.Printf("cleanup error: %v\n", err)
+	}
+	fmt.Println("Hello, workspace!")
+}
+`
+
+	// helloGoContent is a small valid Go file written during the test.
+	helloGoContent = `package main
+
+import "fmt"
+
+func hello() string {
+	return "hello from write_file test"
+}
+
+func init() {
+	fmt.Println(hello())
+}
+`
+)
+
+// TestRemoteDevWorkspaceE2E deploys a remote development workspace proxy to the shared
+// k3s cluster via the in-process operator, then exercises all six command tools:
+// write_file, read_file, list_files, search_files, run_build, and run_lint.
+//
+// The test requires a WORKSPACE_IMAGE environment variable pointing to a container image
+// that includes the proxy binary, Go toolchain, golangci-lint, the write-file helper,
+// and a sample Go project pre-seeded at /workspace.
+//
+// The test:
+//  1. Loads the workspace image into k3s.
+//  2. Creates MCPUpstream CRD with type: command and all 6 tool definitions.
+//  3. Creates MCPProxy CRD pointing to the workspace image.
+//  4. Waits for the proxy pod to become Ready.
+//  5. Port-forwards to the proxy pod and connects an MCP client.
+//  6. Exercises each tool and validates responses.
+//  7. Verifies path traversal is rejected by the write-file helper.
+func TestRemoteDevWorkspaceE2E(t *testing.T) {
+	workspaceImage := os.Getenv("WORKSPACE_IMAGE")
+	if workspaceImage == "" {
+		t.Fatal("WORKSPACE_IMAGE must point to the workspace image built for this test run")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	// ── 1. Load workspace image into k3s ─────────────────────────────────────
+
+	loadImageIntoK3s(ctx, t, globalK3s, workspaceImage)
+
+	// ── 2. Build k8s client ───────────────────────────────────────────────────
+
+	scheme := buildOperatorScheme()
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig(globalK3s.kubeConfigYAML)
+	if err != nil {
+		t.Fatalf("building REST config: %v", err)
+	}
+	k8sClient, err := client.New(restCfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("creating k8s client: %v", err)
+	}
+
+	// ── 3. Create namespace ───────────────────────────────────────────────────
+
+	t.Logf("creating namespace %s", remoteDevNamespace)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: remoteDevNamespace}}
+	if err := k8sClient.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating namespace: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		existing := &corev1.Namespace{}
+		if err := k8sClient.Get(cleanCtx, types.NamespacedName{Name: remoteDevNamespace}, existing); err == nil {
+			if err := k8sClient.Delete(cleanCtx, existing); err != nil && !apierrors.IsNotFound(err) {
+				t.Logf("cleanup: delete namespace %s: %v", remoteDevNamespace, err)
+			}
+		}
+	})
+
+	// ── 4. Start operator in-process ─────────────────────────────────────────
+
+	t.Log("starting operator in-process")
+	stopOperator := startOperator(ctx, t, globalK3s.kubeConfigYAML, scheme)
+	defer stopOperator()
+
+	// ── 5. Create MCPUpstream (type: command) ─────────────────────────────────
+
+	t.Logf("creating MCPUpstream %s/%s", remoteDevNamespace, remoteDevUpstream)
+	upstream := buildRemoteDevUpstream()
+	if err := k8sClient.Create(ctx, upstream); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating MCPUpstream: %v", err)
+	}
+
+	// ── 6. Create MCPProxy ────────────────────────────────────────────────────
+
+	t.Logf("creating MCPProxy %s/%s", remoteDevNamespace, remoteDevProxyName)
+	proxyResource := &v1alpha1.MCPProxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      remoteDevProxyName,
+			Namespace: remoteDevNamespace,
+		},
+		Spec: v1alpha1.MCPProxySpec{
+			UpstreamSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"mcp-anything.ai/proxy": remoteDevProxyName,
+				},
+			},
+			Image: workspaceImage,
+			Server: v1alpha1.ProxyServerSpec{
+				Port: remoteDevProxyPort,
+			},
+			Naming: v1alpha1.ProxyNamingSpec{
+				Separator: "__",
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, proxyResource); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating MCPProxy: %v", err)
+	}
+
+	// ── 7. Wait for proxy pod to be ready ─────────────────────────────────────
+
+	t.Log("waiting for proxy pod to become Ready (up to 5 minutes)")
+	podName, err := waitForProxyPod(ctx, t, k8sClient, remoteDevNamespace, remoteDevProxyName)
+	if err != nil {
+		t.Fatalf("proxy pod not ready: %v", err)
+	}
+	t.Logf("proxy pod ready: %s", podName)
+
+	// ── 8. Port-forward to proxy pod ─────────────────────────────────────────
+
+	localPort, err := findFreeLocalPort()
+	if err != nil {
+		t.Fatalf("finding free local port: %v", err)
+	}
+	t.Logf("port-forwarding localhost:%d → %s:%d", localPort, podName, remoteDevProxyPort)
+
+	stopForward, err := portForwardToPod(ctx, t, restCfg, remoteDevNamespace, podName, localPort, remoteDevProxyPort)
+	if err != nil {
+		t.Fatalf("starting port-forward: %v", err)
+	}
+	defer stopForward()
+
+	proxyURL := fmt.Sprintf("http://localhost:%d", localPort)
+
+	// ── 9. Wait for proxy to be healthy ──────────────────────────────────────
+
+	t.Log("waiting for proxy /healthz endpoint to return 200")
+	healthCtx, healthCancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer healthCancel()
+	if err := waitForHTTPOK(healthCtx, proxyURL+"/healthz"); err != nil {
+		t.Fatalf("proxy healthz not OK: %v", err)
+	}
+	t.Log("proxy is healthy")
+
+	// ── 10. Connect MCP client ────────────────────────────────────────────────
+
+	mcpTransport := &sdkmcp.StreamableClientTransport{
+		Endpoint: proxyURL + "/mcp",
+	}
+	mcpClient := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "remote-dev-test", Version: "v0.0.1"}, nil)
+
+	callCtx, callCancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer callCancel()
+
+	session, err := mcpClient.Connect(callCtx, mcpTransport, nil)
+	if err != nil {
+		t.Fatalf("connect MCP client: %v", err)
+	}
+	defer session.Close()
+
+	// ── 11. Verify tool listing ───────────────────────────────────────────────
+
+	toolsResult, err := session.ListTools(callCtx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	t.Logf("exposed %d tools: %v", len(toolsResult.Tools), toolNames(toolsResult.Tools))
+
+	expectedTools := []string{
+		"dev__write_file",
+		"dev__read_file",
+		"dev__list_files",
+		"dev__search_files",
+		"dev__run_lint",
+		"dev__run_build",
+	}
+	toolSet := make(map[string]bool, len(toolsResult.Tools))
+	for _, tool := range toolsResult.Tools {
+		toolSet[tool.Name] = true
+	}
+	for _, want := range expectedTools {
+		if !toolSet[want] {
+			t.Errorf("expected tool %q not found in tool listing", want)
+		}
+	}
+
+	// ── 12. Write a file ─────────────────────────────────────────────────────
+
+	t.Log("calling dev__write_file to create /workspace/hello.go")
+	writeResult, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{
+		Name: "dev__write_file",
+		Arguments: map[string]any{
+			"path":    "/workspace/hello.go",
+			"content": helloGoContent,
+		},
+	})
+	if err != nil {
+		t.Fatalf("call dev__write_file: %v", err)
+	}
+	if writeResult.IsError {
+		t.Fatalf("dev__write_file returned error: %s", contentText(writeResult.Content))
+	}
+	t.Log("write_file succeeded")
+
+	// ── 13. Read the file back ────────────────────────────────────────────────
+
+	t.Log("calling dev__read_file to verify /workspace/hello.go")
+	readResult, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{
+		Name:      "dev__read_file",
+		Arguments: map[string]any{"path": "/workspace/hello.go"},
+	})
+	if err != nil {
+		t.Fatalf("call dev__read_file: %v", err)
+	}
+	if readResult.IsError {
+		t.Fatalf("dev__read_file returned error: %s", contentText(readResult.Content))
+	}
+	readText := contentText(readResult.Content)
+	if !strings.Contains(readText, "hello from write_file test") {
+		t.Errorf("read_file content does not contain expected string; got: %s", readText)
+	}
+	t.Logf("read_file content verified")
+
+	// ── 14. List files ────────────────────────────────────────────────────────
+
+	t.Log("calling dev__list_files to list *.go files in /workspace")
+	listResult, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{
+		Name: "dev__list_files",
+		Arguments: map[string]any{
+			"directory": "/workspace",
+			"pattern":   "*.go",
+		},
+	})
+	if err != nil {
+		t.Fatalf("call dev__list_files: %v", err)
+	}
+	if listResult.IsError {
+		t.Fatalf("dev__list_files returned error: %s", contentText(listResult.Content))
+	}
+	listText := contentText(listResult.Content)
+	if !strings.Contains(listText, "hello.go") {
+		t.Errorf("list_files output does not contain hello.go; got: %s", listText)
+	}
+	t.Logf("list_files output: %s", listText)
+
+	// ── 15. Search files ──────────────────────────────────────────────────────
+
+	t.Log("calling dev__search_files for 'hello from write_file test' in /workspace")
+	searchResult, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{
+		Name: "dev__search_files",
+		Arguments: map[string]any{
+			"pattern":   "hello from write_file test",
+			"directory": "/workspace",
+		},
+	})
+	if err != nil {
+		t.Fatalf("call dev__search_files: %v", err)
+	}
+	if searchResult.IsError {
+		t.Fatalf("dev__search_files returned error: %s", contentText(searchResult.Content))
+	}
+	searchText := contentText(searchResult.Content)
+	if !strings.Contains(searchText, "hello.go") {
+		t.Errorf("search_files did not find pattern in hello.go; got: %s", searchText)
+	}
+	t.Log("search_files found expected match")
+
+	// ── 16. Run build (expect success) ────────────────────────────────────────
+
+	t.Log("calling dev__run_build with ./...")
+	buildResult, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{
+		Name:      "dev__run_build",
+		Arguments: map[string]any{"path": "./..."},
+	})
+	if err != nil {
+		t.Fatalf("call dev__run_build: %v", err)
+	}
+	if buildResult.IsError {
+		t.Fatalf("dev__run_build returned unexpected error: %s", contentText(buildResult.Content))
+	}
+	t.Log("run_build succeeded (no build errors)")
+
+	// ── 17. Run lint (expect failure on pre-seeded issue) ────────────────────
+
+	t.Log("calling dev__run_lint with ./... (expect lint issues from main.go)")
+	lintResult, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{
+		Name:      "dev__run_lint",
+		Arguments: map[string]any{"path": "./..."},
+	})
+	if err != nil {
+		t.Fatalf("call dev__run_lint: %v", err)
+	}
+	if !lintResult.IsError {
+		t.Fatalf("dev__run_lint expected to return lint issues but IsError=false; output: %s",
+			contentText(lintResult.Content))
+	}
+	lintText := contentText(lintResult.Content)
+	t.Logf("lint issues (expected): %s", lintText)
+
+	// ── 18. Fix lint issue via write_file ─────────────────────────────────────
+
+	t.Log("calling dev__write_file to fix main.go lint issue")
+	fixResult, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{
+		Name: "dev__write_file",
+		Arguments: map[string]any{
+			"path":    "/workspace/main.go",
+			"content": mainGoFixed,
+		},
+	})
+	if err != nil {
+		t.Fatalf("call dev__write_file (fix): %v", err)
+	}
+	if fixResult.IsError {
+		t.Fatalf("dev__write_file (fix) returned error: %s", contentText(fixResult.Content))
+	}
+
+	t.Log("calling dev__run_lint after fix (expect success)")
+	lintFixed, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{
+		Name:      "dev__run_lint",
+		Arguments: map[string]any{"path": "./..."},
+	})
+	if err != nil {
+		t.Fatalf("call dev__run_lint (after fix): %v", err)
+	}
+	if lintFixed.IsError {
+		t.Fatalf("dev__run_lint still reports issues after fix: %s", contentText(lintFixed.Content))
+	}
+	t.Log("lint passes after fix")
+
+	// ── 19. Path traversal rejection ─────────────────────────────────────────
+
+	t.Log("calling dev__write_file with path traversal (expect error)")
+	traversalResult, err := session.CallTool(callCtx, &sdkmcp.CallToolParams{
+		Name: "dev__write_file",
+		Arguments: map[string]any{
+			"path":    "../../../etc/passwd",
+			"content": "malicious content",
+		},
+	})
+	if err != nil {
+		t.Fatalf("call dev__write_file (traversal): %v", err)
+	}
+	if !traversalResult.IsError {
+		t.Fatalf("dev__write_file with path traversal should have returned error, but succeeded")
+	}
+	t.Logf("path traversal correctly rejected: %s", contentText(traversalResult.Content))
+}
+
+// buildRemoteDevUpstream constructs the MCPUpstream CRD for the remote-dev test.
+func buildRemoteDevUpstream() *v1alpha1.MCPUpstream {
+	return &v1alpha1.MCPUpstream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      remoteDevUpstream,
+			Namespace: remoteDevNamespace,
+			Labels: map[string]string{
+				"mcp-anything.ai/proxy": remoteDevProxyName,
+			},
+		},
+		Spec: v1alpha1.MCPUpstreamSpec{
+			Type:       "command",
+			ToolPrefix: "dev",
+			Commands: []v1alpha1.MCPUpstreamCommandSpec{
+				{
+					ToolName:    "write_file",
+					Description: "Write content to a file in the workspace",
+					Command:     "/usr/local/bin/write-file {{.path}} {{.content}}",
+					Timeout:     "10s",
+					InputSchema: &v1alpha1.MCPUpstreamCommandInputSchema{
+						Type: "object",
+						Properties: map[string]v1alpha1.MCPUpstreamCommandSchemaProperty{
+							"path": {
+								Type:        "string",
+								Description: "File path relative to /workspace (or absolute path under /workspace)",
+							},
+							"content": {
+								Type:        "string",
+								Description: "File content to write",
+							},
+						},
+						Required: []string{"path", "content"},
+					},
+				},
+				{
+					ToolName:    "read_file",
+					Description: "Read the contents of a file",
+					Command:     "cat {{.path}}",
+					Timeout:     "10s",
+					InputSchema: &v1alpha1.MCPUpstreamCommandInputSchema{
+						Type: "object",
+						Properties: map[string]v1alpha1.MCPUpstreamCommandSchemaProperty{
+							"path": {
+								Type:        "string",
+								Description: "Absolute file path to read",
+							},
+						},
+						Required: []string{"path"},
+					},
+				},
+				{
+					ToolName:    "list_files",
+					Description: "List files matching a pattern in a directory",
+					Command:     "find {{.directory}} -type f -name {{.pattern}}",
+					Timeout:     "10s",
+					InputSchema: &v1alpha1.MCPUpstreamCommandInputSchema{
+						Type: "object",
+						Properties: map[string]v1alpha1.MCPUpstreamCommandSchemaProperty{
+							"directory": {
+								Type:        "string",
+								Description: "Directory to search in",
+							},
+							"pattern": {
+								Type:        "string",
+								Description: "File name glob pattern (e.g. *.go)",
+							},
+						},
+						Required: []string{"directory", "pattern"},
+					},
+				},
+				{
+					ToolName:    "search_files",
+					Description: "Search file contents for a pattern (grep)",
+					Command:     "grep -rn {{.pattern}} {{.directory}}",
+					Timeout:     "30s",
+					InputSchema: &v1alpha1.MCPUpstreamCommandInputSchema{
+						Type: "object",
+						Properties: map[string]v1alpha1.MCPUpstreamCommandSchemaProperty{
+							"pattern": {
+								Type:        "string",
+								Description: "Search pattern (fixed string or regex)",
+							},
+							"directory": {
+								Type:        "string",
+								Description: "Directory to search in",
+							},
+						},
+						Required: []string{"pattern", "directory"},
+					},
+				},
+				{
+					ToolName:    "run_lint",
+					Description: "Run Go linter and return diagnostics",
+					Command:     "golangci-lint run {{.path}}",
+					WorkingDir:  "/workspace",
+					Timeout:     "60s",
+					InputSchema: &v1alpha1.MCPUpstreamCommandInputSchema{
+						Type: "object",
+						Properties: map[string]v1alpha1.MCPUpstreamCommandSchemaProperty{
+							"path": {
+								Type:        "string",
+								Description: "Package path to lint (e.g. ./...)",
+							},
+						},
+						Required: []string{"path"},
+					},
+				},
+				{
+					ToolName:    "run_build",
+					Description: "Run Go build and return errors",
+					Command:     "go build {{.path}}",
+					WorkingDir:  "/workspace",
+					Timeout:     "60s",
+					InputSchema: &v1alpha1.MCPUpstreamCommandInputSchema{
+						Type: "object",
+						Properties: map[string]v1alpha1.MCPUpstreamCommandSchemaProperty{
+							"path": {
+								Type:        "string",
+								Description: "Package path to build (e.g. ./...)",
+							},
+						},
+						Required: []string{"path"},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Implements issue #105: CRD support for command upstreams, write-file helper binary, remote dev workspace example, and E2E test.

Closes #105

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCPUpstream now supports command-based tools (new type: http|command) enabling local command execution in addition to HTTP backends.

* **Examples**
  * Added a remote-dev workspace example (image, config, proxy, sample project) preconfigured for file operations and Go tooling.

* **Tools**
  * Exposes command-based tools: write_file, read_file, list_files, search_files, run_lint, run_build.

* **Tests**
  * Added an end-to-end test validating the remote-dev workspace and tool workflows.

* **Security**
  * File-write operations include path traversal protection and atomic writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->