### PR TITLE
refactor: unify inbound auth, outbound auth, and transform interfaces to standard http.Handler middleware (#110)

### DIFF
--- a/pkg/auth/outbound/context.go
+++ b/pkg/auth/outbound/context.go
@@ -1,0 +1,39 @@
+package outbound
+
+import (
+	"context"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// outboundHeadersKey is the unexported context key for outbound auth headers.
+type outboundHeadersKey struct{}
+
+// outboundResultKey is the unexported context key for an early-exit tool result
+// produced by the outbound auth middleware (e.g. on AuthRequiredError).
+type outboundResultKey struct{}
+
+// HeadersFromContext retrieves outbound auth headers stored by the Middleware constructor.
+// Returns nil when no headers have been set.
+func HeadersFromContext(ctx context.Context) map[string]string {
+	h, _ := ctx.Value(outboundHeadersKey{}).(map[string]string)
+	return h
+}
+
+// withHeaders stores outbound auth headers in ctx under the package-private outboundHeadersKey.
+func withHeaders(ctx context.Context, headers map[string]string) context.Context {
+	return context.WithValue(ctx, outboundHeadersKey{}, headers)
+}
+
+// AuthResultFromContext retrieves an early-exit CallToolResult set by the outbound auth
+// middleware (e.g. when an OAuth2 redirect is required). Returns nil when normal
+// execution should continue.
+func AuthResultFromContext(ctx context.Context) *sdkmcp.CallToolResult {
+	r, _ := ctx.Value(outboundResultKey{}).(*sdkmcp.CallToolResult)
+	return r
+}
+
+// withAuthResult stores an early-exit result in ctx under the package-private outboundResultKey.
+func withAuthResult(ctx context.Context, result *sdkmcp.CallToolResult) context.Context {
+	return context.WithValue(ctx, outboundResultKey{}, result)
+}

--- a/pkg/auth/outbound/middleware.go
+++ b/pkg/auth/outbound/middleware.go
@@ -1,0 +1,70 @@
+package outbound
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Middleware wraps a TokenProvider as an HTTP middleware for the per-tool execution chain.
+// It resolves outbound credentials and stores them in context for the terminal handler.
+//
+// On success, auth headers are stored via withHeaders.
+// On AuthRequiredError (e.g. OAuth2 user redirect needed), a CallToolResult is stored
+// via withAuthResult so the terminal handler can return it without making an upstream call.
+// On any other error, an error CallToolResult is stored via withAuthResult.
+//
+// next is always called so that the terminal handler can write the result to the pipeline state.
+// The terminal handler must check AuthResultFromContext before proceeding with the HTTP call.
+func Middleware(provider TokenProvider) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			rawHeaders, err := provider.RawHeaders(ctx)
+			if err != nil {
+				ctx = withAuthResult(ctx, authErrResult(err))
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+
+			if len(rawHeaders) > 0 {
+				ctx = withHeaders(ctx, rawHeaders)
+			} else {
+				token, tokenErr := provider.Token(ctx)
+				if tokenErr != nil {
+					ctx = withAuthResult(ctx, authErrResult(tokenErr))
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
+				if token != "" {
+					ctx = withHeaders(ctx, map[string]string{"Authorization": "Bearer " + token})
+				}
+			}
+
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// authErrResult converts an outbound auth error into a CallToolResult.
+// AuthRequiredError produces the OAuth2 authorization redirect message.
+func authErrResult(err error) *sdkmcp.CallToolResult {
+	var authErr *AuthRequiredError
+	if errors.As(err, &authErr) {
+		return &sdkmcp.CallToolResult{
+			IsError: true,
+			Content: []sdkmcp.Content{
+				&sdkmcp.TextContent{Text: "Authorization required. Please visit the following URL to grant access:\n" + authErr.AuthURL},
+			},
+		}
+	}
+	return &sdkmcp.CallToolResult{
+		IsError: true,
+		Content: []sdkmcp.Content{
+			&sdkmcp.TextContent{Text: fmt.Sprintf("outbound auth error: %v", err)},
+		},
+	}
+}

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -1,0 +1,23 @@
+// Package middleware defines the canonical Middleware type for mcp-anything.
+// All pluggable processing stages — inbound auth, outbound auth, transforms,
+// and rate limiting — are expressed as Middleware so they can be composed
+// into a linear chain with standard net/http tooling.
+package middleware
+
+import "net/http"
+
+// Middleware is the standard HTTP middleware type: it wraps an http.Handler and
+// returns a new one. Middleware is applied in a linear chain; the innermost
+// handler is the tool executor.
+type Middleware func(http.Handler) http.Handler
+
+// Chain composes multiple Middleware into a single Middleware, applying them
+// left-to-right (the first Middleware is the outermost wrapper).
+func Chain(ms ...Middleware) Middleware {
+	return func(next http.Handler) http.Handler {
+		for i := len(ms) - 1; i >= 0; i-- {
+			next = ms[i](next)
+		}
+		return next
+	}
+}

--- a/pkg/transform/context.go
+++ b/pkg/transform/context.go
@@ -1,0 +1,48 @@
+package transform
+
+import "context"
+
+// mcpArgsKey is the unexported context key for MCP tool call arguments.
+type mcpArgsKey struct{}
+
+// envelopeKey is the unexported context key for the compiled RequestEnvelope.
+type envelopeKey struct{}
+
+// transformErrKey is the unexported context key for a request-transform error.
+type transformErrKey struct{}
+
+// WithMCPArgs stores MCP tool call arguments in ctx for the request-transform middleware.
+func WithMCPArgs(ctx context.Context, args map[string]any) context.Context {
+	return context.WithValue(ctx, mcpArgsKey{}, args)
+}
+
+// MCPArgsFromContext retrieves MCP tool call arguments stored by WithMCPArgs.
+// Returns nil if no arguments are present.
+func MCPArgsFromContext(ctx context.Context) map[string]any {
+	args, _ := ctx.Value(mcpArgsKey{}).(map[string]any)
+	return args
+}
+
+// RequestEnvelopeFromContext retrieves the RequestEnvelope stored by the
+// request-transform middleware. Returns nil when no envelope is present.
+func RequestEnvelopeFromContext(ctx context.Context) *RequestEnvelope {
+	env, _ := ctx.Value(envelopeKey{}).(*RequestEnvelope)
+	return env
+}
+
+// withEnvelope stores env in ctx under the package-private envelopeKey.
+func withEnvelope(ctx context.Context, env *RequestEnvelope) context.Context {
+	return context.WithValue(ctx, envelopeKey{}, env)
+}
+
+// ErrorFromContext retrieves a transform error set by the request-transform middleware.
+// Returns nil when no error is present.
+func ErrorFromContext(ctx context.Context) error {
+	err, _ := ctx.Value(transformErrKey{}).(error)
+	return err
+}
+
+// withTransformError stores err in ctx under the package-private transformErrKey.
+func withTransformError(ctx context.Context, err error) context.Context {
+	return context.WithValue(ctx, transformErrKey{}, err)
+}

--- a/pkg/transform/middleware.go
+++ b/pkg/transform/middleware.go
@@ -1,0 +1,29 @@
+package transform
+
+import (
+	"net/http"
+)
+
+// RequestMiddleware returns an HTTP middleware that runs the request transform.
+// It reads MCP tool arguments from context (stored via WithMCPArgs), executes
+// the request jq expression, and stores the resulting RequestEnvelope in context.
+//
+// On failure the error is stored in context via withTransformError and next is
+// still called so that the terminal handler can write the error to the pipeline state.
+// The terminal handler must check TransformErrorFromContext before proceeding.
+func (c *CompiledTransforms) RequestMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			args := MCPArgsFromContext(ctx)
+
+			envelope, err := c.RunRequest(ctx, args)
+			if err != nil {
+				next.ServeHTTP(w, r.WithContext(withTransformError(ctx, err)))
+				return
+			}
+
+			next.ServeHTTP(w, r.WithContext(withEnvelope(ctx, envelope)))
+		})
+	}
+}

--- a/pkg/upstream/http/builder.go
+++ b/pkg/upstream/http/builder.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/http"
+	nethttp "net/http"
 	"strings"
 	"time"
 
@@ -51,7 +51,7 @@ func (b *Builder) Build(ctx context.Context, cfg *config.UpstreamConfig, naming 
 		return nil, fmt.Errorf("build outbound auth for upstream %q: %w", cfg.Name, err)
 	}
 
-	client, err := NewHTTPClient(cfg, provider)
+	client, err := NewHTTPClient(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("building HTTP client for upstream %q: %w", cfg.Name, err)
 	}
@@ -68,7 +68,7 @@ func (b *Builder) Build(ctx context.Context, cfg *config.UpstreamConfig, naming 
 	if fetchTimeout <= 0 {
 		fetchTimeout = 30 * time.Second
 	}
-	uiFetchClient := &http.Client{Timeout: fetchTimeout}
+	uiFetchClient := &nethttp.Client{Timeout: fetchTimeout}
 
 	entries := make([]*pkgupstream.RegistryEntry, 0, len(tools))
 	for _, vt := range tools {
@@ -97,7 +97,17 @@ func (b *Builder) Build(ctx context.Context, cfg *config.UpstreamConfig, naming 
 			RateLimit:      rateLimit,
 			CacheName:      resolveCacheName(vt.Operation, cfg.Cache),
 		}
-		entry.Executor = &Executor{entry: entry}
+		executor := &Executor{entry: entry}
+		entry.Executor = executor
+
+		// Compose the per-tool middleware chain:
+		//   RequestMiddleware (transform) → outbound.Middleware (auth) → Executor (terminal handler)
+		var h nethttp.Handler = executor
+		h = pkgoutbound.Middleware(provider)(h)
+		if vt.Transforms != nil {
+			h = vt.Transforms.RequestMiddleware()(h)
+		}
+		entry.Handler = h
 
 		// Load and attach a UI handler when a UI source is configured for this tool.
 		// buildUIHandler returns nil, nil when no UI factory is registered (pkg/upstream/http/withui not imported).

--- a/pkg/upstream/http/client.go
+++ b/pkg/upstream/http/client.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	pkginbound "github.com/gaarutyunov/mcp-anything/pkg/auth/inbound"
-	pkgoutbound "github.com/gaarutyunov/mcp-anything/pkg/auth/outbound"
 	"github.com/gaarutyunov/mcp-anything/pkg/config"
 	pkgtelemetry "github.com/gaarutyunov/mcp-anything/pkg/telemetry"
 	pkgtransport "github.com/gaarutyunov/mcp-anything/pkg/transport"
@@ -53,8 +52,9 @@ func (t *tokenInfoHeaderTransport) RoundTrip(req *nethttp.Request) (*nethttp.Res
 // It uses cfg.Transport for connection pooling, TLS, and dialing settings.
 // The legacy cfg.TLSSkipVerify field is honoured for backward compatibility.
 // Static headers from cfg.Headers are injected via a custom RoundTripper.
-// The provider wraps the transport to inject outbound authentication on every request.
-func NewHTTPClient(cfg *config.UpstreamConfig, provider pkgoutbound.TokenProvider) (*nethttp.Client, error) {
+// Outbound authentication is handled by the per-tool middleware chain (outbound.Middleware)
+// rather than a RoundTripper, so no auth transport is added here.
+func NewHTTPClient(cfg *config.UpstreamConfig) (*nethttp.Client, error) {
 	transportCfg := cfg.Transport
 	// Legacy tls_skip_verify field: propagate to transport TLS config for backward compat.
 	if cfg.TLSSkipVerify {
@@ -70,8 +70,6 @@ func NewHTTPClient(cfg *config.UpstreamConfig, provider pkgoutbound.TokenProvide
 	if len(cfg.Headers) > 0 {
 		rt = &headerRoundTripper{headers: cfg.Headers, wrapped: t}
 	}
-
-	rt = &pkgoutbound.AuthTransport{Base: rt, Provider: provider}
 
 	// Inject extra headers from the inbound TokenInfo (e.g. from Lua check_auth extra_headers).
 	rt = &tokenInfoHeaderTransport{wrapped: rt}

--- a/pkg/upstream/http/executor.go
+++ b/pkg/upstream/http/executor.go
@@ -28,42 +28,113 @@ import (
 	pkgcb "github.com/gaarutyunov/mcp-anything/pkg/upstream/circuitbreaker"
 )
 
+// callState holds the mutable result of a per-tool execution pipeline.
+// It is allocated by Execute and shared via context with the handler chain
+// so any handler in the chain can write the final result.
+type callState struct {
+	result *sdkmcp.CallToolResult
+	err    error
+}
+
+// callStateKey is the unexported context key for callState.
+type callStateKey struct{}
+
+// withCallState stores s in ctx and returns the updated context.
+func withCallState(ctx context.Context, s *callState) context.Context {
+	return context.WithValue(ctx, callStateKey{}, s)
+}
+
+// callStateFromContext retrieves the callState from ctx, or nil if absent.
+func callStateFromContext(ctx context.Context) *callState {
+	s, _ := ctx.Value(callStateKey{}).(*callState)
+	return s
+}
+
+// noopResponseWriter discards all HTTP writes; results are communicated via callState.
+type noopResponseWriter struct{}
+
+func (noopResponseWriter) Header() nethttp.Header      { return nethttp.Header{} }
+func (noopResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (noopResponseWriter) WriteHeader(int)             {}
+
 // Executor executes an HTTP-backed tool by running the full request pipeline:
 // request transform → URL build → request validation → HTTP call → response validation → response transform.
 type Executor struct {
 	entry *pkgupstream.RegistryEntry
 }
 
-// Execute runs the HTTP request pipeline for the given tool args.
+// Execute runs the per-tool handler chain and returns the MCP result.
+// The chain (entry.Handler) applies request transforms and outbound auth before
+// reaching ServeHTTP (the terminal handler) which performs the upstream HTTP call.
 func (e *Executor) Execute(ctx context.Context, args map[string]any) (*sdkmcp.CallToolResult, error) {
+	state := &callState{}
+	ctx = withCallState(ctx, state)
+	ctx = transform.WithMCPArgs(ctx, args)
+
+	req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, "http://internal/", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating internal pipeline request: %w", err)
+	}
+
+	e.entry.Handler.ServeHTTP(noopResponseWriter{}, req)
+
+	return state.result, state.err
+}
+
+// ServeHTTP is the terminal handler in the per-tool middleware chain.
+// It reads the RequestEnvelope and outbound auth headers from context,
+// builds and dispatches the upstream HTTP request, and writes the result
+// to the callState in context.
+func (e *Executor) ServeHTTP(w nethttp.ResponseWriter, r *nethttp.Request) {
+	ctx := r.Context()
+	state := callStateFromContext(ctx)
+	if state == nil {
+		slog.Error("ServeHTTP called without callState in context", "tool", e.entry.PrefixedName)
+		return
+	}
+
 	entry := e.entry
 	toolAttrs := metric.WithAttributes(attribute.String("mcp.tool.name", entry.PrefixedName))
 
-	// Get the typed transforms (set by the HTTP builder).
-	transforms, ok := entry.Transforms.(*transform.CompiledTransforms)
-	if !ok || transforms == nil {
-		return nil, fmt.Errorf("invalid transforms for tool %q: expected *transform.CompiledTransforms", entry.PrefixedName)
+	// Check for request transform error (set by RequestMiddleware on failure).
+	if tErr := transform.ErrorFromContext(ctx); tErr != nil {
+		if pkgtelemetry.ToolCallErrors != nil {
+			pkgtelemetry.ToolCallErrors.Add(ctx, 1, toolAttrs)
+		}
+		state.result = &sdkmcp.CallToolResult{
+			IsError: true,
+			Content: []sdkmcp.Content{
+				&sdkmcp.TextContent{Text: fmt.Sprintf("request transform: %v", tErr)},
+			},
+		}
+		return
 	}
 
-	// Apply request transform jq → RequestEnvelope.
-	reqStart := time.Now()
-	envelope, err := transforms.RunRequest(ctx, args)
-	if err != nil {
-		return nil, fmt.Errorf("request transform: %w", err)
+	// Check for outbound auth early-exit result (e.g. OAuth2 redirect needed).
+	if authResult := pkgoutbound.AuthResultFromContext(ctx); authResult != nil {
+		state.result = authResult
+		return
 	}
-	if pkgtelemetry.TransformDuration != nil {
-		pkgtelemetry.TransformDuration.Record(ctx, time.Since(reqStart).Seconds(),
-			metric.WithAttributes(
-				attribute.String("mcp.tool.name", entry.PrefixedName),
-				attribute.String("transform.stage", "request"),
-			),
-		)
+
+	// Get compiled transforms for response/error processing.
+	transforms, ok := entry.Transforms.(*transform.CompiledTransforms)
+	if !ok || transforms == nil {
+		state.err = fmt.Errorf("invalid transforms for tool %q: expected *transform.CompiledTransforms", entry.PrefixedName)
+		return
+	}
+
+	// Get the request envelope produced by RequestMiddleware.
+	envelope := transform.RequestEnvelopeFromContext(ctx)
+	if envelope == nil {
+		state.err = fmt.Errorf("no request envelope in context for tool %q", entry.PrefixedName)
+		return
 	}
 
 	// Build upstream URL from the envelope.
 	upstreamURL, err := buildUpstreamURL(entry.Upstream.BaseURL, entry.PathTemplate, envelope)
 	if err != nil {
-		return nil, fmt.Errorf("building upstream URL: %w", err)
+		state.err = fmt.Errorf("building upstream URL: %w", err)
+		return
 	}
 
 	// Build request body if present.
@@ -71,7 +142,8 @@ func (e *Executor) Execute(ctx context.Context, args map[string]any) (*sdkmcp.Ca
 	if envelope.Body != nil {
 		bodyBytes, marshalErr := json.Marshal(envelope.Body)
 		if marshalErr != nil {
-			return nil, fmt.Errorf("marshalling request body: %w", marshalErr)
+			state.err = fmt.Errorf("marshalling request body: %w", marshalErr)
+			return
 		}
 		bodyReader = bytes.NewReader(bodyBytes)
 	}
@@ -79,13 +151,20 @@ func (e *Executor) Execute(ctx context.Context, args map[string]any) (*sdkmcp.Ca
 	// Create HTTP request.
 	httpReq, err := nethttp.NewRequestWithContext(ctx, entry.Method, upstreamURL, bodyReader)
 	if err != nil {
-		return nil, fmt.Errorf("creating HTTP request: %w", err)
+		state.err = fmt.Errorf("creating HTTP request: %w", err)
+		return
 	}
 
 	// Add envelope headers; static upstream headers are injected by the RoundTripper.
 	for k, v := range envelope.Headers {
 		httpReq.Header.Set(k, v)
 	}
+
+	// Add outbound auth headers (from Middleware); these override envelope headers for auth.
+	for k, v := range pkgoutbound.HeadersFromContext(ctx) {
+		httpReq.Header.Set(k, v)
+	}
+
 	if bodyReader != nil {
 		httpReq.Header.Set("Content-Type", "application/json")
 	}
@@ -94,19 +173,18 @@ func (e *Executor) Execute(ctx context.Context, args map[string]any) (*sdkmcp.Ca
 	validator, _ := entry.Validator.(*openapi.Validator)
 
 	// Validate the outbound request against the OpenAPI spec (if configured).
-	// When only response validation is enabled, we still build the route metadata
-	// (BuildRequestInput) so that ValidateResponse has the required context.
 	var reqInput *openapi3filter.RequestValidationInput
 	if validator != nil {
 		if entry.ValidationCfg.ValidateRequest {
 			ri, valErr := validator.ValidateRequest(ctx, httpReq)
 			if valErr != nil {
-				return &sdkmcp.CallToolResult{
+				state.result = &sdkmcp.CallToolResult{
 					IsError: true,
 					Content: []sdkmcp.Content{
 						&sdkmcp.TextContent{Text: fmt.Sprintf("request validation failed: %v", valErr)},
 					},
-				}, nil
+				}
+				return
 			}
 			reqInput = ri
 		} else if entry.ValidationCfg.ValidateResponse {
@@ -119,41 +197,35 @@ func (e *Executor) Execute(ctx context.Context, args map[string]any) (*sdkmcp.Ca
 		}
 	}
 
-	// Inject outbound auth — no-op for now; TASK-10 fills this in.
-
 	// Dispatch: with or without circuit breaker.
 	cb := entry.Upstream.CircuitBreaker
 	if cb == nil {
-		// No circuit breaker — original flow.
 		result, _, dispErr := e.httpDispatchWithStatus(ctx, httpReq, reqInput, transforms, validator, toolAttrs)
-		return result, dispErr
+		state.result = result
+		state.err = dispErr
+		return
 	}
 
 	// Circuit-breaker-wrapped flow.
 	result, cbErr := cb.Execute(func() (*sdkmcp.CallToolResult, error) {
 		res, statusCode, dispErr := e.httpDispatchWithStatus(ctx, httpReq, reqInput, transforms, validator, toolAttrs)
 		if dispErr != nil {
-			// Network error or I/O failure → count as circuit failure.
 			return nil, dispErr
 		}
 		if statusCode >= 500 {
-			// 5xx response → count as circuit failure but preserve the result
-			// so the LLM receives the actual error body.
 			return res, pkgcb.ErrUpstreamFailure
 		}
-		// 2xx or 4xx → not a circuit failure (upstream is healthy or request was invalid).
 		return res, nil
 	})
 
 	switch {
 	case errors.Is(cbErr, gobreaker.ErrOpenState), errors.Is(cbErr, gobreaker.ErrTooManyRequests):
-		// Circuit is open or half-open limit reached — fail fast without hitting upstream.
-		return openCircuitResult(cb), nil
+		state.result = openCircuitResult(cb)
 	case errors.Is(cbErr, pkgcb.ErrUpstreamFailure):
-		// 5xx was counted as a circuit failure; return the preserved error result to the LLM.
-		return result, nil
+		state.result = result
 	default:
-		return result, cbErr
+		state.result = result
+		state.err = cbErr
 	}
 }
 
@@ -183,16 +255,6 @@ func (e *Executor) httpDispatchWithStatus(
 
 	resp, err := entry.Upstream.Client.Do(httpReq)
 	if err != nil {
-		// Check if the outbound auth strategy requires user authorization.
-		var authErr *pkgoutbound.AuthRequiredError
-		if errors.As(err, &authErr) {
-			return &sdkmcp.CallToolResult{
-				IsError: true,
-				Content: []sdkmcp.Content{
-					&sdkmcp.TextContent{Text: "Authorization required. Please visit the following URL to grant access:\n" + authErr.AuthURL},
-				},
-			}, 0, nil
-		}
 		return nil, 0, fmt.Errorf("executing HTTP request: %w", err)
 	}
 	defer func() {

--- a/pkg/upstream/http/refresh.go
+++ b/pkg/upstream/http/refresh.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	nethttp "net/http"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -304,7 +305,7 @@ func (r *Refresher) buildEntriesFromBytes(ctx context.Context, mergedBytes []byt
 		return nil, nil, nil, nil, fmt.Errorf("building outbound auth: %w", err)
 	}
 
-	client, err := NewHTTPClient(r.cfg, provider)
+	client, err := NewHTTPClient(r.cfg)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("building HTTP client: %w", err)
 	}
@@ -337,7 +338,18 @@ func (r *Refresher) buildEntriesFromBytes(ctx context.Context, mergedBytes []byt
 			ValidationCfg:  r.cfg.Validation,
 			OperationNode:  gt.OperationNode,
 		}
-		entry.Executor = &Executor{entry: entry}
+		executor := &Executor{entry: entry}
+		entry.Executor = executor
+
+		// Compose the per-tool middleware chain:
+		//   RequestMiddleware (transform) → outbound.Middleware (auth) → Executor (terminal handler)
+		var h nethttp.Handler = executor
+		h = pkgoutbound.Middleware(provider)(h)
+		if vt.Transforms != nil {
+			h = vt.Transforms.RequestMiddleware()(h)
+		}
+		entry.Handler = h
+
 		entries = append(entries, entry)
 	}
 

--- a/pkg/upstream/registry.go
+++ b/pkg/upstream/registry.go
@@ -58,6 +58,10 @@ type RegistryEntry struct {
 	ValidationCfg  config.ValidationConfig
 	OperationNode  *yaml.Node   // YAML node for JSONPath group filter evaluation (nil for command/script tools)
 	Executor       ToolExecutor // set by builders; dispatches tool execution
+	// Handler is the composed per-tool middleware chain assembled by HTTP builders.
+	// The chain applies request transforms and outbound auth before reaching the
+	// terminal executor handler. Nil for non-HTTP tools (command, script).
+	Handler http.Handler
 	// RateLimit is the name of a top-level rate_limits entry applied to this tool.
 	// Empty string means no rate limiting. Set by builders from the x-mcp-rate-limit
 	// overlay extension (per-tool override) or upstream-level rate_limit config (default).


### PR DESCRIPTION
Closes #110

Introduces the canonical Middleware type and converts all per-tool processing stages to standard `func(http.Handler) http.Handler` so they compose linearly.

## Changes

- `pkg/middleware`: new package with Middleware type and Chain() helper
- `pkg/transform/context.go`: context helpers for MCP args, RequestEnvelope, and transform errors
- `pkg/transform/middleware.go`: RequestMiddleware() method on *CompiledTransforms
- `pkg/auth/outbound/context.go`: context helpers for outbound auth headers and early-exit CallToolResult
- `pkg/auth/outbound/middleware.go`: Middleware() constructor wrapping TokenProvider
- `pkg/upstream/registry.go`: Handler http.Handler field on RegistryEntry
- `pkg/upstream/http/executor.go`: Executor now implements http.Handler; Execute() invokes entry.Handler chain
- `pkg/upstream/http/builder.go`, `refresh.go`: compose the chain and set entry.Handler
- `pkg/upstream/http/client.go`: remove AuthTransport from NewHTTPClient

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized outbound authentication and request transformation to operate through a unified middleware pipeline architecture per tool. This improves code modularity and ensures consistent application of authentication and transforms across all tool invocations without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->