### PR TITLE
feat: add generic Registry[T any] and replace all custom registries

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -12,12 +12,12 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/gaarutyunov/mcp-anything/pkg/config"
+	"github.com/gaarutyunov/mcp-anything/pkg/registry"
 )
 
 // Store is the interface for a cache backend.
@@ -32,17 +32,12 @@ type Store interface {
 // StoreFactory creates a Store from config.
 type StoreFactory func(ctx context.Context, cfg *config.CacheStoreConfig) (Store, error)
 
-var (
-	mu       sync.RWMutex
-	registry = make(map[string]StoreFactory)
-)
+var reg registry.Registry[StoreFactory]
 
 // Register adds a factory for the given provider name.
 // Typically called from init() in store sub-packages.
 func Register(provider string, factory StoreFactory) {
-	mu.Lock()
-	defer mu.Unlock()
-	registry[provider] = factory
+	reg.Register(provider, factory)
 }
 
 // New creates a Store from config.
@@ -52,9 +47,7 @@ func New(ctx context.Context, cfg *config.CacheStoreConfig) (Store, error) {
 	if provider == "" {
 		provider = "memory"
 	}
-	mu.RLock()
-	f, ok := registry[provider]
-	mu.RUnlock()
+	f, ok := reg.Get(provider)
 	if !ok {
 		return nil, fmt.Errorf("unknown cache store provider %q — did you forget to import _ %q?",
 			provider,

--- a/pkg/embedding/embedding.go
+++ b/pkg/embedding/embedding.go
@@ -13,11 +13,11 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sync"
 
 	chromem "github.com/philippgille/chromem-go"
 
 	"github.com/gaarutyunov/mcp-anything/pkg/config"
+	"github.com/gaarutyunov/mcp-anything/pkg/registry"
 )
 
 // Func is the embedding function type used to embed text into a vector.
@@ -28,26 +28,19 @@ type Func = chromem.EmbeddingFunc
 // ProviderFactory creates an embedding Func from an EmbeddingConfig.
 type ProviderFactory func(ctx context.Context, cfg *config.EmbeddingConfig) (Func, error)
 
-var (
-	mu       sync.RWMutex
-	registry = make(map[string]ProviderFactory)
-)
+var reg registry.Registry[ProviderFactory]
 
 // Register adds a factory for the given provider name.
 // Typically called from init() in provider sub-packages.
 func Register(provider string, factory ProviderFactory) {
-	mu.Lock()
-	defer mu.Unlock()
-	registry[provider] = factory
+	reg.Register(provider, factory)
 }
 
 // New creates an embedding Func from the given config.
 // Returns an error for unknown providers.
 // Provider sub-packages must be imported (blank import) before calling New.
 func New(ctx context.Context, cfg *config.EmbeddingConfig) (Func, error) {
-	mu.RLock()
-	f, ok := registry[cfg.Provider]
-	mu.RUnlock()
+	f, ok := reg.Get(cfg.Provider)
 	if !ok {
 		return nil, fmt.Errorf("unknown embedding provider %q — import the provider package or pkg/embedding/all", cfg.Provider)
 	}

--- a/pkg/middleware/registry.go
+++ b/pkg/middleware/registry.go
@@ -8,7 +8,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sync"
+
+	"github.com/gaarutyunov/mcp-anything/pkg/registry"
 )
 
 // Factory creates a middleware from a generic config value.
@@ -16,27 +17,20 @@ import (
 // Factories are registered from init() in strategy sub-packages.
 type Factory func(ctx context.Context, cfg any) (func(http.Handler) http.Handler, error)
 
-var (
-	regMu sync.RWMutex
-	reg   = make(map[string]Factory)
-)
+var reg registry.Registry[Factory]
 
 // Register adds a factory for the given name.
 // Typically called from init() in strategy sub-packages.
 // Names should be namespaced (e.g. "inbound/jwt", "outbound/bearer", "ratelimit/client_ip").
 func Register(name string, f Factory) {
-	regMu.Lock()
-	defer regMu.Unlock()
-	reg[name] = f
+	reg.Register(name, f)
 }
 
 // New builds the appropriate middleware from config.
 // Returns an error for unknown names; strategy sub-packages must be imported
 // (blank import) before calling New.
 func New(ctx context.Context, name string, cfg any) (func(http.Handler) http.Handler, error) {
-	regMu.RLock()
-	f, ok := reg[name]
-	regMu.RUnlock()
+	f, ok := reg.Get(name)
 	if !ok {
 		return nil, fmt.Errorf("unknown middleware %q — did you forget to import the strategy sub-package?", name)
 	}

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -16,13 +16,13 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/ulule/limiter/v3"
 
 	"github.com/gaarutyunov/mcp-anything/pkg/config"
 	pkgmiddleware "github.com/gaarutyunov/mcp-anything/pkg/middleware"
+	"github.com/gaarutyunov/mcp-anything/pkg/registry"
 )
 
 func init() {
@@ -35,17 +35,12 @@ func init() {
 // Called from init() in store sub-packages.
 type StoreFactory func(ctx context.Context, cfg *config.ProxyConfig) (limiter.Store, error)
 
-var (
-	storeMu        sync.RWMutex
-	storeFactories = make(map[string]StoreFactory)
-)
+var storeFactories registry.Registry[StoreFactory]
 
 // Register adds a store factory for the given store type name.
 // Typically called from init() in store sub-packages.
 func Register(name string, f StoreFactory) {
-	storeMu.Lock()
-	defer storeMu.Unlock()
-	storeFactories[name] = f
+	storeFactories.Register(name, f)
 }
 
 // clientIPKey is an unexported context key for storing the client IP.
@@ -111,9 +106,7 @@ func New(ctx context.Context, cfg *config.ProxyConfig) (*Enforcer, error) {
 		storeName = "redis"
 	}
 
-	storeMu.RLock()
-	factory, ok := storeFactories[storeName]
-	storeMu.RUnlock()
+	factory, ok := storeFactories.Get(storeName)
 	if !ok {
 		return nil, fmt.Errorf(
 			"unknown rate limit store %q — import the store package or pkg/ratelimit/all",

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,0 +1,72 @@
+// Package registry provides a generic, thread-safe, string-keyed registry
+// used throughout mcp-anything for pluggable components (middleware factories,
+// store factories, upstream builders, etc.).
+//
+// The zero value of Registry is ready to use — no constructor is needed.
+// Each pluggable sub-system declares a package-level variable of the appropriate
+// concrete type:
+//
+//	var middlewareRegistry registry.Registry[middleware.Factory]
+//	var cacheRegistry      registry.Registry[cache.StoreFactory]
+//
+// Sub-packages register themselves from their init() functions:
+//
+//	func init() { middlewareRegistry.Register("jwt", newJWT) }
+package registry
+
+import "sync"
+
+// Registry is a thread-safe, string-keyed store for named values of type T.
+// The zero value is ready to use.
+type Registry[T any] struct {
+	mu    sync.RWMutex
+	items map[string]T
+}
+
+// Register adds or replaces the value for key.
+// Safe for concurrent use.
+func (r *Registry[T]) Register(key string, value T) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.items == nil {
+		r.items = make(map[string]T)
+	}
+	r.items[key] = value
+}
+
+// RegisterIfAbsent sets the value for key only if it does not already exist.
+// Returns true if the key was newly registered, false if it was already present.
+// Safe for concurrent use.
+func (r *Registry[T]) RegisterIfAbsent(key string, value T) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.items == nil {
+		r.items = make(map[string]T)
+	}
+	if _, exists := r.items[key]; exists {
+		return false
+	}
+	r.items[key] = value
+	return true
+}
+
+// Get returns the value for key and whether it was found.
+// Safe for concurrent use.
+func (r *Registry[T]) Get(key string) (T, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	v, ok := r.items[key]
+	return v, ok
+}
+
+// Snapshot returns a shallow copy of all entries, safe for iteration
+// without holding the registry lock.
+func (r *Registry[T]) Snapshot() map[string]T {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]T, len(r.items))
+	for k, v := range r.items {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/runtime/registry.go
+++ b/pkg/runtime/registry.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sync"
 
 	"github.com/gaarutyunov/mcp-anything/pkg/config"
+	"github.com/gaarutyunov/mcp-anything/pkg/registry"
 )
 
 const (
@@ -21,25 +21,18 @@ const (
 // via Register in its init() function.
 type Factory func(ctx context.Context, cfg config.RuntimeConfig) (Runtime, error)
 
-var (
-	mu        sync.RWMutex
-	factories = map[string]Factory{}
-)
+var factories registry.Registry[Factory]
 
 // Register registers a Factory under the given name. Typically called from init()
 // in a scripting sub-package. Logs and skips if name is empty or already registered.
 func Register(name string, f Factory) {
-	mu.Lock()
-	defer mu.Unlock()
 	if name == "" {
 		slog.Error("runtime.Register: name must not be empty")
 		return
 	}
-	if _, dup := factories[name]; dup {
+	if !factories.RegisterIfAbsent(name, f) {
 		slog.Error("runtime.Register: duplicate runtime name", "name", name)
-		return
 	}
-	factories[name] = f
 }
 
 // Registry holds a bounded Runtime pool for every registered scripting runtime.
@@ -53,12 +46,7 @@ type Registry struct {
 // NewRegistry creates a Registry by calling every registered Factory.
 // Returns an error if any factory returns an error.
 func NewRegistry(ctx context.Context, cfg config.RuntimeConfig) (*Registry, error) {
-	mu.RLock()
-	snap := make(map[string]Factory, len(factories))
-	for k, v := range factories {
-		snap[k] = v
-	}
-	mu.RUnlock()
+	snap := factories.Snapshot()
 
 	pools := make(map[string]Runtime, len(snap))
 	for name, f := range snap {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -7,9 +7,9 @@ package session
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/gaarutyunov/mcp-anything/pkg/config"
+	"github.com/gaarutyunov/mcp-anything/pkg/registry"
 )
 
 // Token is an alias for config.OAuthToken for convenience in session sub-packages.
@@ -21,17 +21,12 @@ type Store = config.OAuthTokenStore
 // StoreFactory creates a Store from a SessionStoreConfig.
 type StoreFactory func(ctx context.Context, cfg *config.SessionStoreConfig) (Store, error)
 
-var (
-	mu       sync.RWMutex
-	registry = make(map[string]StoreFactory)
-)
+var reg registry.Registry[StoreFactory]
 
 // Register adds a factory for the given provider name.
 // Typically called from init() in session sub-packages.
 func Register(provider string, f StoreFactory) {
-	mu.Lock()
-	defer mu.Unlock()
-	registry[provider] = f
+	reg.Register(provider, f)
 }
 
 // New creates a Store from the given config.
@@ -40,9 +35,7 @@ func New(ctx context.Context, cfg *config.SessionStoreConfig) (Store, error) {
 	if cfg.Provider == "" {
 		return nil, fmt.Errorf("session_store.provider is required")
 	}
-	mu.RLock()
-	f, ok := registry[cfg.Provider]
-	mu.RUnlock()
+	f, ok := reg.Get(cfg.Provider)
 	if !ok {
 		return nil, fmt.Errorf("unknown session store provider %q — import _ %q",
 			cfg.Provider,

--- a/pkg/upstream/upstream.go
+++ b/pkg/upstream/upstream.go
@@ -8,11 +8,11 @@ package upstream
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/gaarutyunov/mcp-anything/pkg/config"
+	"github.com/gaarutyunov/mcp-anything/pkg/registry"
 )
 
 // ToolExecutor executes a single tool call and returns the MCP result.
@@ -27,26 +27,19 @@ type Builder interface {
 	Build(ctx context.Context, cfg *config.UpstreamConfig, naming *config.NamingConfig) (*ValidatedUpstream, error)
 }
 
-var (
-	buildersMu sync.RWMutex
-	builders   = make(map[string]Builder)
-)
+var builders registry.Registry[Builder]
 
 // RegisterBuilder registers a Builder for the given upstream type name.
 // Typically called from init() in upstream type sub-packages.
 func RegisterBuilder(upstreamType string, b Builder) {
-	buildersMu.Lock()
-	defer buildersMu.Unlock()
-	builders[upstreamType] = b
+	builders.Register(upstreamType, b)
 }
 
 // Build dispatches to the registered Builder for cfg.Type and returns
 // a ValidatedUpstream ready for use in the tool registry.
 // Returns an error if no builder is registered for the upstream type.
 func Build(ctx context.Context, cfg *config.UpstreamConfig, naming *config.NamingConfig) (*ValidatedUpstream, error) {
-	buildersMu.RLock()
-	b, ok := builders[cfg.Type]
-	buildersMu.RUnlock()
+	b, ok := builders.Get(cfg.Type)
 	if !ok {
 		return nil, fmt.Errorf("unknown upstream type %q — did you forget to import _ %q?",
 			cfg.Type,


### PR DESCRIPTION
Add a generic `Registry[T any]` type in `pkg/registry` and replace the seven custom map+mutex registries across middleware, cache, ratelimit, embedding, session, upstream, and runtime packages.

Closes #122

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal registry management across multiple packages to use a unified, generic thread-safe registry abstraction, improving code consistency and maintainability while preserving all existing public APIs and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->