### PR TITLE
feat: always collect coverage from proxy and operator containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+coverage/
 *.test
 *.out
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,16 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /proxy ./cmd/proxy
+RUN CGO_ENABLED=0 go build -cover -coverpkg=github.com/gaarutyunov/mcp-anything/... -o /proxy ./cmd/proxy
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates
 # TIKTOKEN_CACHE_DIR points tiktoken-go to a writable, predictable cache directory.
 # BPE encoding data is downloaded on first use if not already cached.
 ENV TIKTOKEN_CACHE_DIR=/tmp/tiktoken_cache
+# GOCOVERDIR is where the coverage-instrumented binary writes its data on exit.
+# Bind-mount a host directory here to collect coverage from the container.
+ENV GOCOVERDIR=/tmp/gocov
+RUN mkdir -p /tmp/gocov
 COPY --from=builder /proxy /usr/local/bin/proxy
 ENTRYPOINT ["proxy"]

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -4,12 +4,16 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /operator ./cmd/operator
+RUN CGO_ENABLED=0 go build -cover -coverpkg=github.com/gaarutyunov/mcp-anything/... -o /operator ./cmd/operator
 
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates \
     && addgroup -S -g 65532 operator \
     && adduser -S -u 65532 -G operator operator
+# GOCOVERDIR is where the coverage-instrumented binary writes its data on exit.
+# Bind-mount a host directory here to collect coverage from the container.
+ENV GOCOVERDIR=/tmp/gocov
+RUN mkdir -p /tmp/gocov && chown 65532:65532 /tmp/gocov
 COPY --from=builder /operator /usr/local/bin/operator
 RUN chown 65532:65532 /usr/local/bin/operator
 USER 65532:65532

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-operator lint vet test integration treeshake check clean helm-lint helm-package helm-push generate-crds lint-crds build-linter
+.PHONY: all build build-operator lint vet test integration treeshake check clean helm-lint helm-package helm-push generate-crds lint-crds build-linter cover-merge cover-report
 
 BINARY := bin/proxy
 OPERATOR_BINARY := bin/operator
@@ -7,6 +7,7 @@ GOFLAGS := -race
 INTEGRATION_TIMEOUT := 600s
 E2E_TEST ?=
 E2E_RUN_FLAG = $(if $(E2E_TEST),-run $(E2E_TEST),)
+COVERAGE_DIR ?= $(CURDIR)/coverage
 
 HELM_CHART_DIR := charts/mcp-anything
 HELM_DIST_DIR := dist
@@ -30,10 +31,12 @@ vet:
 	go vet ./...
 
 test:
-	go test $(GOFLAGS) -count=1 ./...
+	mkdir -p $(COVERAGE_DIR)/unit
+	GOCOVERDIR=$(COVERAGE_DIR)/unit go test $(GOFLAGS) -cover -coverpkg=./... -count=1 ./...
 
 integration:
-	go test $(GOFLAGS) -tags integration -count=1 -timeout $(INTEGRATION_TIMEOUT) ./tests/integration/...
+	mkdir -p $(COVERAGE_DIR)/integration
+	GOCOVERDIR=$(COVERAGE_DIR)/integration COVERAGE_DIR=$(COVERAGE_DIR)/integration go test $(GOFLAGS) -tags integration -cover -coverpkg=./... -count=1 -timeout $(INTEGRATION_TIMEOUT) ./tests/integration/...
 
 e2e:
 	go test $(GOFLAGS) -tags e2e -count=1 -timeout $(INTEGRATION_TIMEOUT) $(E2E_RUN_FLAG) ./tests/e2e/...
@@ -48,6 +51,14 @@ lint-crds:
 	go run ./cmd/crdlint
 
 check: lint vet test build build-operator treeshake
+
+cover-merge:
+	mkdir -p $(COVERAGE_DIR)/merged
+	go tool covdata merge -i $(COVERAGE_DIR)/unit,$(COVERAGE_DIR)/integration -o $(COVERAGE_DIR)/merged
+	go tool covdata textfmt -i $(COVERAGE_DIR)/merged -o $(COVERAGE_DIR)/coverage.out
+
+cover-report: cover-merge
+	go tool cover -func=$(COVERAGE_DIR)/coverage.out
 
 clean:
 	rm -rf bin/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Website](https://img.shields.io/badge/website-mcp--anything.ai-blue)](https://mcp-anything.ai)
 [![License](https://img.shields.io/github/license/gaarutyunov/mcp-anything)](LICENSE)
 [![CI](https://github.com/gaarutyunov/mcp-anything/actions/workflows/ci.yml/badge.svg)](https://github.com/gaarutyunov/mcp-anything/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/gaarutyunov/mcp-anything/branch/main/graph/badge.svg)](https://codecov.io/gh/gaarutyunov/mcp-anything)
 
 A stateless Go proxy that turns **anything** — REST APIs, shell commands, JavaScript scripts — into [MCP](https://modelcontextprotocol.io) tools. No code, no plugins — just config.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        # 80% threshold for the overall project (existing code).
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        # 100% threshold for new/changed lines in PRs.
+        target: 100%
+        threshold: 0%

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/caddyserver/caddy/v2 v2.11.2
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dgraph-io/ristretto v0.2.0
+	github.com/docker/docker v28.5.2+incompatible
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/getkin/kin-openapi v0.134.0
 	github.com/go-chi/chi/v5 v5.2.5
@@ -148,7 +149,6 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
-	github.com/docker/docker v28.5.2+incompatible // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960 // indirect

--- a/tests/integration/mvp_test.go
+++ b/tests/integration/mvp_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	dockercontainer "github.com/docker/docker/api/types/container"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/network"
@@ -23,16 +24,25 @@ import (
 
 // proxyContainerRequest returns a ContainerRequest for the proxy.
 // If PROXY_IMAGE is set, it pulls that image. Otherwise, it builds from source using the Dockerfile.
+// If COVERAGE_DIR is set, it bind-mounts that directory to /tmp/gocov inside the container so that
+// the coverage-instrumented binary flushes its data to the host when the container stops.
 func proxyContainerRequest() testcontainers.ContainerRequest {
+	req := testcontainers.ContainerRequest{}
 	if img := os.Getenv("PROXY_IMAGE"); img != "" {
-		return testcontainers.ContainerRequest{Image: img}
-	}
-	return testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
+		req.Image = img
+	} else {
+		req.FromDockerfile = testcontainers.FromDockerfile{
 			Context:    "../..",
 			Dockerfile: "Dockerfile",
-		},
+		}
 	}
+	if coverDir := os.Getenv("COVERAGE_DIR"); coverDir != "" {
+		bind := coverDir + ":/tmp/gocov"
+		req.HostConfigModifier = func(hc *dockercontainer.HostConfig) {
+			hc.Binds = append(hc.Binds, bind)
+		}
+	}
+	return req
 }
 
 const testOpenAPISpec = `openapi: "3.0.0"


### PR DESCRIPTION
Closes #128

## Summary

- `Dockerfile` / `Dockerfile.operator`: always build with `-cover -coverpkg=...`; add `GOCOVERDIR=/tmp/gocov`
- `Makefile`: `test` and `integration` always collect coverage; add `cover-merge` / `cover-report` targets
- `tests/integration/mvp_test.go`: bind-mount `COVERAGE_DIR` into proxy container via `HostConfigModifier`
- `codecov.yml`: 100% patch threshold, 80% project threshold
- `README.md`: Codecov badge

CI workflow changes are documented in the issue comment and must be applied manually.

Generated with [Claude Code](https://claude.ai/code)