### PR TITLE
refactor: eliminate middleware transformer functions, implement middleware directly on structs

### DIFF
--- a/pkg/auth/inbound/apikey/apikey.go
+++ b/pkg/auth/inbound/apikey/apikey.go
@@ -25,19 +25,20 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return v.Middleware(ic.APIKey.Header), nil
+		return v.Wrap, nil
 	})
 }
 
 // Validator validates tokens by checking them against a set of allowed API keys.
-// The "token" passed to ValidateToken is the value of the configured header.
+// The token is read from the header configured at construction time.
 type Validator struct {
-	inbound.ValidatorBase
-	keys map[string]struct{}
+	header string
+	keys   map[string]struct{}
 }
 
 // NewValidator creates a Validator by reading keys from the environment variable
 // named cfg.KeysEnv (comma-separated list of valid keys).
+// The header name from cfg.Header is stored and used in Wrap.
 func NewValidator(cfg config.APIKeyAuthConfig) (*Validator, error) {
 	raw := os.Getenv(cfg.KeysEnv)
 	keys := make(map[string]struct{})
@@ -50,9 +51,7 @@ func NewValidator(cfg config.APIKeyAuthConfig) (*Validator, error) {
 	if len(keys) == 0 {
 		return nil, fmt.Errorf("no API keys found in environment variable %q", cfg.KeysEnv)
 	}
-	v := &Validator{keys: keys}
-	v.ValidatorBase = inbound.NewValidatorBase(v)
-	return v, nil
+	return &Validator{header: cfg.Header, keys: keys}, nil
 }
 
 // ValidateToken checks whether token (the API key value) is in the allowed key set.
@@ -61,4 +60,11 @@ func (v *Validator) ValidateToken(_ context.Context, token string) (*inbound.Tok
 		return nil, errors.New("invalid API key")
 	}
 	return &inbound.TokenInfo{}, nil
+}
+
+// Wrap implements inbound.Middleware. It reads the API key from the configured header.
+func (v *Validator) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inbound.ServeValidated(w, r, next, v, r.Header.Get(v.header))
+	})
 }

--- a/pkg/auth/inbound/apikey/apikey.go
+++ b/pkg/auth/inbound/apikey/apikey.go
@@ -25,13 +25,14 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return inbound.ValidatorMiddleware(v, ic.APIKey.Header), nil
+		return v.Middleware(ic.APIKey.Header), nil
 	})
 }
 
 // Validator validates tokens by checking them against a set of allowed API keys.
 // The "token" passed to ValidateToken is the value of the configured header.
 type Validator struct {
+	inbound.ValidatorBase
 	keys map[string]struct{}
 }
 
@@ -49,7 +50,9 @@ func NewValidator(cfg config.APIKeyAuthConfig) (*Validator, error) {
 	if len(keys) == 0 {
 		return nil, fmt.Errorf("no API keys found in environment variable %q", cfg.KeysEnv)
 	}
-	return &Validator{keys: keys}, nil
+	v := &Validator{keys: keys}
+	v.ValidatorBase = inbound.NewValidatorBase(v)
+	return v, nil
 }
 
 // ValidateToken checks whether token (the API key value) is in the allowed key set.

--- a/pkg/auth/inbound/apikey/apikey.go
+++ b/pkg/auth/inbound/apikey/apikey.go
@@ -16,18 +16,12 @@ import (
 )
 
 func init() {
-	pkgmiddleware.Register("inbound/apikey", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
+	pkgmiddleware.Register("inbound/apikey", func(_ context.Context, cfg any) (pkgmiddleware.Builder, error) {
 		ic, ok := cfg.(*config.InboundAuthConfig)
 		if !ok {
 			return nil, fmt.Errorf("inbound/apikey: expected *config.InboundAuthConfig, got %T", cfg)
 		}
-		v, err := NewValidator(ic.APIKey)
-		if err != nil {
-			return nil, err
-		}
-		return func(next http.Handler) http.Handler {
-			return &Validator{header: v.header, keys: v.keys, Next: next}
-		}, nil
+		return NewValidator(ic.APIKey)
 	})
 }
 
@@ -56,6 +50,11 @@ func NewValidator(cfg config.APIKeyAuthConfig) (*Validator, error) {
 	return &Validator{header: cfg.Header, keys: keys}, nil
 }
 
+// Build implements middleware.Builder. It returns a Validator wired to next.
+func (v *Validator) Build(next http.Handler) http.Handler {
+	return &Validator{header: v.header, keys: v.keys, Next: next}
+}
+
 // ValidateToken checks whether token (the API key value) is in the allowed key set.
 func (v *Validator) ValidateToken(_ context.Context, token string) (*inbound.TokenInfo, error) {
 	if _, ok := v.keys[token]; !ok {
@@ -66,5 +65,20 @@ func (v *Validator) ValidateToken(_ context.Context, token string) (*inbound.Tok
 
 // ServeHTTP implements http.Handler. It reads the API key from the configured header.
 func (v *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	inbound.ServeValidated(w, r, v.Next, v, r.Header.Get(v.header))
+	token := r.Header.Get(v.header)
+	if token == "" {
+		inbound.WriteUnauthorized(w, r, "missing_token")
+		return
+	}
+	info, err := v.ValidateToken(r.Context(), token)
+	if err != nil {
+		var denied *inbound.DeniedError
+		if errors.As(err, &denied) {
+			inbound.WriteDenied(w, r, denied)
+		} else {
+			inbound.WriteUnauthorized(w, r, "invalid_token")
+		}
+		return
+	}
+	v.Next.ServeHTTP(w, r.WithContext(inbound.WithTokenInfo(r.Context(), info)))
 }

--- a/pkg/auth/inbound/apikey/apikey.go
+++ b/pkg/auth/inbound/apikey/apikey.go
@@ -25,7 +25,9 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return v.Wrap, nil
+		return func(next http.Handler) http.Handler {
+			return &Validator{header: v.header, keys: v.keys, Next: next}
+		}, nil
 	})
 }
 
@@ -34,11 +36,11 @@ func init() {
 type Validator struct {
 	header string
 	keys   map[string]struct{}
+	Next   http.Handler
 }
 
 // NewValidator creates a Validator by reading keys from the environment variable
 // named cfg.KeysEnv (comma-separated list of valid keys).
-// The header name from cfg.Header is stored and used in Wrap.
 func NewValidator(cfg config.APIKeyAuthConfig) (*Validator, error) {
 	raw := os.Getenv(cfg.KeysEnv)
 	keys := make(map[string]struct{})
@@ -62,9 +64,7 @@ func (v *Validator) ValidateToken(_ context.Context, token string) (*inbound.Tok
 	return &inbound.TokenInfo{}, nil
 }
 
-// Wrap implements inbound.Middleware. It reads the API key from the configured header.
-func (v *Validator) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		inbound.ServeValidated(w, r, next, v, r.Header.Get(v.header))
-	})
+// ServeHTTP implements http.Handler. It reads the API key from the configured header.
+func (v *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	inbound.ServeValidated(w, r, v.Next, v, r.Header.Get(v.header))
 }

--- a/pkg/auth/inbound/inbound.go
+++ b/pkg/auth/inbound/inbound.go
@@ -7,6 +7,7 @@ package inbound
 import (
 	"context"
 	"fmt"
+	"net/http"
 )
 
 // DeniedError is returned by a TokenValidator when access is explicitly denied
@@ -50,17 +51,15 @@ func TokenInfoFromContext(ctx context.Context) *TokenInfo {
 	return v
 }
 
-// ValidatorBase can be embedded in any concrete TokenValidator struct to provide
-// the Middleware() method directly on the struct.
-// Call NewValidatorBase(v) in the constructor to wire the self-reference.
-type ValidatorBase struct {
-	self TokenValidator
+// Middleware is implemented by all inbound auth validators.
+// Each concrete validator type implements Wrap directly on the struct.
+type Middleware interface {
+	Wrap(next http.Handler) http.Handler
 }
 
-// NewValidatorBase creates a ValidatorBase wired to v.
-// Assign the result to the embedded ValidatorBase field of your concrete type:
-//
-//	v.ValidatorBase = inbound.NewValidatorBase(v)
-func NewValidatorBase(v TokenValidator) ValidatorBase {
-	return ValidatorBase{self: v}
-}
+// MiddlewareFunc adapts a func(http.Handler) http.Handler to implement Middleware.
+// This mirrors the http.HandlerFunc / http.Handler pattern.
+type MiddlewareFunc func(http.Handler) http.Handler
+
+// Wrap implements Middleware.
+func (f MiddlewareFunc) Wrap(next http.Handler) http.Handler { return f(next) }

--- a/pkg/auth/inbound/inbound.go
+++ b/pkg/auth/inbound/inbound.go
@@ -7,7 +7,6 @@ package inbound
 import (
 	"context"
 	"fmt"
-	"net/http"
 )
 
 // DeniedError is returned by a TokenValidator when access is explicitly denied
@@ -50,16 +49,3 @@ func TokenInfoFromContext(ctx context.Context) *TokenInfo {
 	v, _ := ctx.Value(contextKey{}).(*TokenInfo)
 	return v
 }
-
-// Middleware is implemented by all inbound auth validators.
-// Each concrete validator type implements Wrap directly on the struct.
-type Middleware interface {
-	Wrap(next http.Handler) http.Handler
-}
-
-// MiddlewareFunc adapts a func(http.Handler) http.Handler to implement Middleware.
-// This mirrors the http.HandlerFunc / http.Handler pattern.
-type MiddlewareFunc func(http.Handler) http.Handler
-
-// Wrap implements Middleware.
-func (f MiddlewareFunc) Wrap(next http.Handler) http.Handler { return f(next) }

--- a/pkg/auth/inbound/inbound.go
+++ b/pkg/auth/inbound/inbound.go
@@ -49,3 +49,18 @@ func TokenInfoFromContext(ctx context.Context) *TokenInfo {
 	v, _ := ctx.Value(contextKey{}).(*TokenInfo)
 	return v
 }
+
+// ValidatorBase can be embedded in any concrete TokenValidator struct to provide
+// the Middleware() method directly on the struct.
+// Call NewValidatorBase(v) in the constructor to wire the self-reference.
+type ValidatorBase struct {
+	self TokenValidator
+}
+
+// NewValidatorBase creates a ValidatorBase wired to v.
+// Assign the result to the embedded ValidatorBase field of your concrete type:
+//
+//	v.ValidatorBase = inbound.NewValidatorBase(v)
+func NewValidatorBase(v TokenValidator) ValidatorBase {
+	return ValidatorBase{self: v}
+}

--- a/pkg/auth/inbound/inbound.go
+++ b/pkg/auth/inbound/inbound.go
@@ -49,3 +49,8 @@ func TokenInfoFromContext(ctx context.Context) *TokenInfo {
 	v, _ := ctx.Value(contextKey{}).(*TokenInfo)
 	return v
 }
+
+// WithTokenInfo stores info in ctx for retrieval by TokenInfoFromContext.
+func WithTokenInfo(ctx context.Context, info *TokenInfo) context.Context {
+	return context.WithValue(ctx, contextKey{}, info)
+}

--- a/pkg/auth/inbound/introspection/introspection.go
+++ b/pkg/auth/inbound/introspection/introspection.go
@@ -28,13 +28,12 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return v.Middleware(""), nil
+		return v.Wrap, nil
 	})
 }
 
 // Validator validates tokens by calling a token introspection endpoint.
 type Validator struct {
-	inbound.ValidatorBase
 	server rs.ResourceServer
 	aud    string
 }
@@ -47,9 +46,7 @@ func NewValidator(ctx context.Context, cfg config.IntrospectionConfig) (*Validat
 	if err != nil {
 		return nil, fmt.Errorf("creating introspection resource server: %w", err)
 	}
-	v := &Validator{server: server, aud: cfg.Audience}
-	v.ValidatorBase = inbound.NewValidatorBase(v)
-	return v, nil
+	return &Validator{server: server, aud: cfg.Audience}, nil
 }
 
 // ValidateToken introspects the token and checks it is active and has the expected audience.
@@ -68,4 +65,11 @@ func (v *Validator) ValidateToken(ctx context.Context, raw string) (*inbound.Tok
 		Subject:  resp.Subject,
 		Audience: resp.Audience,
 	}, nil
+}
+
+// Wrap implements inbound.Middleware. It extracts a Bearer token and validates it.
+func (v *Validator) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inbound.ServeValidated(w, r, next, v, inbound.ExtractBearerToken(r))
+	})
 }

--- a/pkg/auth/inbound/introspection/introspection.go
+++ b/pkg/auth/inbound/introspection/introspection.go
@@ -28,7 +28,9 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return v.Wrap, nil
+		return func(next http.Handler) http.Handler {
+			return &Validator{server: v.server, aud: v.aud, Next: next}
+		}, nil
 	})
 }
 
@@ -36,6 +38,7 @@ func init() {
 type Validator struct {
 	server rs.ResourceServer
 	aud    string
+	Next   http.Handler
 }
 
 // NewValidator creates a Validator using client credentials.
@@ -67,9 +70,7 @@ func (v *Validator) ValidateToken(ctx context.Context, raw string) (*inbound.Tok
 	}, nil
 }
 
-// Wrap implements inbound.Middleware. It extracts a Bearer token and validates it.
-func (v *Validator) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		inbound.ServeValidated(w, r, next, v, inbound.ExtractBearerToken(r))
-	})
+// ServeHTTP implements http.Handler. It extracts a Bearer token and validates it.
+func (v *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	inbound.ServeValidated(w, r, v.Next, v, inbound.ExtractBearerToken(r))
 }

--- a/pkg/auth/inbound/introspection/introspection.go
+++ b/pkg/auth/inbound/introspection/introspection.go
@@ -19,18 +19,12 @@ import (
 )
 
 func init() {
-	pkgmiddleware.Register("inbound/introspection", func(ctx context.Context, cfg any) (func(http.Handler) http.Handler, error) {
+	pkgmiddleware.Register("inbound/introspection", func(ctx context.Context, cfg any) (pkgmiddleware.Builder, error) {
 		ic, ok := cfg.(*config.InboundAuthConfig)
 		if !ok {
 			return nil, fmt.Errorf("inbound/introspection: expected *config.InboundAuthConfig, got %T", cfg)
 		}
-		v, err := NewValidator(ctx, ic.Introspection)
-		if err != nil {
-			return nil, err
-		}
-		return func(next http.Handler) http.Handler {
-			return &Validator{server: v.server, aud: v.aud, Next: next}
-		}, nil
+		return NewValidator(ctx, ic.Introspection)
 	})
 }
 
@@ -50,6 +44,11 @@ func NewValidator(ctx context.Context, cfg config.IntrospectionConfig) (*Validat
 		return nil, fmt.Errorf("creating introspection resource server: %w", err)
 	}
 	return &Validator{server: server, aud: cfg.Audience}, nil
+}
+
+// Build implements middleware.Builder. It returns a Validator wired to next.
+func (v *Validator) Build(next http.Handler) http.Handler {
+	return &Validator{server: v.server, aud: v.aud, Next: next}
 }
 
 // ValidateToken introspects the token and checks it is active and has the expected audience.
@@ -72,5 +71,20 @@ func (v *Validator) ValidateToken(ctx context.Context, raw string) (*inbound.Tok
 
 // ServeHTTP implements http.Handler. It extracts a Bearer token and validates it.
 func (v *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	inbound.ServeValidated(w, r, v.Next, v, inbound.ExtractBearerToken(r))
+	token := inbound.ExtractBearerToken(r)
+	if token == "" {
+		inbound.WriteUnauthorized(w, r, "missing_token")
+		return
+	}
+	info, err := v.ValidateToken(r.Context(), token)
+	if err != nil {
+		var denied *inbound.DeniedError
+		if errors.As(err, &denied) {
+			inbound.WriteDenied(w, r, denied)
+		} else {
+			inbound.WriteUnauthorized(w, r, "invalid_token")
+		}
+		return
+	}
+	v.Next.ServeHTTP(w, r.WithContext(inbound.WithTokenInfo(r.Context(), info)))
 }

--- a/pkg/auth/inbound/introspection/introspection.go
+++ b/pkg/auth/inbound/introspection/introspection.go
@@ -28,12 +28,13 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return inbound.ValidatorMiddleware(v, ""), nil
+		return v.Middleware(""), nil
 	})
 }
 
 // Validator validates tokens by calling a token introspection endpoint.
 type Validator struct {
+	inbound.ValidatorBase
 	server rs.ResourceServer
 	aud    string
 }
@@ -46,7 +47,9 @@ func NewValidator(ctx context.Context, cfg config.IntrospectionConfig) (*Validat
 	if err != nil {
 		return nil, fmt.Errorf("creating introspection resource server: %w", err)
 	}
-	return &Validator{server: server, aud: cfg.Audience}, nil
+	v := &Validator{server: server, aud: cfg.Audience}
+	v.ValidatorBase = inbound.NewValidatorBase(v)
+	return v, nil
 }
 
 // ValidateToken introspects the token and checks it is active and has the expected audience.

--- a/pkg/auth/inbound/jwt/jwt.go
+++ b/pkg/auth/inbound/jwt/jwt.go
@@ -25,12 +25,13 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return inbound.ValidatorMiddleware(v, ""), nil
+		return v.Middleware(""), nil
 	})
 }
 
 // Validator validates JWT Bearer tokens using OIDC/JWKS.
 type Validator struct {
+	inbound.ValidatorBase
 	verifier *oidc.IDTokenVerifier
 }
 
@@ -51,7 +52,9 @@ func NewValidator(ctx context.Context, cfg config.JWTAuthConfig) (*Validator, er
 		verifier = provider.Verifier(oidcConfig)
 	}
 
-	return &Validator{verifier: verifier}, nil
+	v := &Validator{verifier: verifier}
+	v.ValidatorBase = inbound.NewValidatorBase(v)
+	return v, nil
 }
 
 // ValidateToken verifies the JWT signature, expiry, and audience, then returns TokenInfo.

--- a/pkg/auth/inbound/jwt/jwt.go
+++ b/pkg/auth/inbound/jwt/jwt.go
@@ -25,13 +25,12 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return v.Middleware(""), nil
+		return v.Wrap, nil
 	})
 }
 
 // Validator validates JWT Bearer tokens using OIDC/JWKS.
 type Validator struct {
-	inbound.ValidatorBase
 	verifier *oidc.IDTokenVerifier
 }
 
@@ -52,9 +51,7 @@ func NewValidator(ctx context.Context, cfg config.JWTAuthConfig) (*Validator, er
 		verifier = provider.Verifier(oidcConfig)
 	}
 
-	v := &Validator{verifier: verifier}
-	v.ValidatorBase = inbound.NewValidatorBase(v)
-	return v, nil
+	return &Validator{verifier: verifier}, nil
 }
 
 // ValidateToken verifies the JWT signature, expiry, and audience, then returns TokenInfo.
@@ -76,4 +73,11 @@ func (v *Validator) ValidateToken(ctx context.Context, raw string) (*inbound.Tok
 		Scopes:   strings.Fields(claims.Scope),
 		Audience: token.Audience,
 	}, nil
+}
+
+// Wrap implements inbound.Middleware. It extracts a Bearer token and validates it.
+func (v *Validator) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inbound.ServeValidated(w, r, next, v, inbound.ExtractBearerToken(r))
+	})
 }

--- a/pkg/auth/inbound/jwt/jwt.go
+++ b/pkg/auth/inbound/jwt/jwt.go
@@ -25,13 +25,16 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return v.Wrap, nil
+		return func(next http.Handler) http.Handler {
+			return &Validator{verifier: v.verifier, Next: next}
+		}, nil
 	})
 }
 
 // Validator validates JWT Bearer tokens using OIDC/JWKS.
 type Validator struct {
 	verifier *oidc.IDTokenVerifier
+	Next     http.Handler
 }
 
 // NewValidator creates a Validator from the given config.
@@ -75,9 +78,7 @@ func (v *Validator) ValidateToken(ctx context.Context, raw string) (*inbound.Tok
 	}, nil
 }
 
-// Wrap implements inbound.Middleware. It extracts a Bearer token and validates it.
-func (v *Validator) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		inbound.ServeValidated(w, r, next, v, inbound.ExtractBearerToken(r))
-	})
+// ServeHTTP implements http.Handler. It extracts a Bearer token and validates it.
+func (v *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	inbound.ServeValidated(w, r, v.Next, v, inbound.ExtractBearerToken(r))
 }

--- a/pkg/auth/inbound/jwt/jwt.go
+++ b/pkg/auth/inbound/jwt/jwt.go
@@ -4,6 +4,7 @@ package jwt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -16,18 +17,12 @@ import (
 )
 
 func init() {
-	pkgmiddleware.Register("inbound/jwt", func(ctx context.Context, cfg any) (func(http.Handler) http.Handler, error) {
+	pkgmiddleware.Register("inbound/jwt", func(ctx context.Context, cfg any) (pkgmiddleware.Builder, error) {
 		ic, ok := cfg.(*config.InboundAuthConfig)
 		if !ok {
 			return nil, fmt.Errorf("inbound/jwt: expected *config.InboundAuthConfig, got %T", cfg)
 		}
-		v, err := NewValidator(ctx, ic.JWT)
-		if err != nil {
-			return nil, err
-		}
-		return func(next http.Handler) http.Handler {
-			return &Validator{verifier: v.verifier, Next: next}
-		}, nil
+		return NewValidator(ctx, ic.JWT)
 	})
 }
 
@@ -57,6 +52,11 @@ func NewValidator(ctx context.Context, cfg config.JWTAuthConfig) (*Validator, er
 	return &Validator{verifier: verifier}, nil
 }
 
+// Build implements middleware.Builder. It returns a Validator wired to next.
+func (v *Validator) Build(next http.Handler) http.Handler {
+	return &Validator{verifier: v.verifier, Next: next}
+}
+
 // ValidateToken verifies the JWT signature, expiry, and audience, then returns TokenInfo.
 func (v *Validator) ValidateToken(ctx context.Context, raw string) (*inbound.TokenInfo, error) {
 	token, err := v.verifier.Verify(ctx, raw)
@@ -80,5 +80,20 @@ func (v *Validator) ValidateToken(ctx context.Context, raw string) (*inbound.Tok
 
 // ServeHTTP implements http.Handler. It extracts a Bearer token and validates it.
 func (v *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	inbound.ServeValidated(w, r, v.Next, v, inbound.ExtractBearerToken(r))
+	token := inbound.ExtractBearerToken(r)
+	if token == "" {
+		inbound.WriteUnauthorized(w, r, "missing_token")
+		return
+	}
+	info, err := v.ValidateToken(r.Context(), token)
+	if err != nil {
+		var denied *inbound.DeniedError
+		if errors.As(err, &denied) {
+			inbound.WriteDenied(w, r, denied)
+		} else {
+			inbound.WriteUnauthorized(w, r, "invalid_token")
+		}
+		return
+	}
+	v.Next.ServeHTTP(w, r.WithContext(inbound.WithTokenInfo(r.Context(), info)))
 }

--- a/pkg/auth/inbound/middleware.go
+++ b/pkg/auth/inbound/middleware.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 )
 
-// ValidatorMiddleware returns an HTTP middleware that validates inbound Bearer tokens
+// Middleware returns an HTTP middleware that validates inbound Bearer tokens
 // (or API keys when apiKeyHeader is non-empty).
-// It extracts the token, calls ValidateToken, and stores the resulting TokenInfo in ctx.
+// It extracts the token, calls ValidateToken on the embedded validator, and stores
+// the resulting TokenInfo in the request context.
 // It does NOT implement per-tool auth bypass — use DispatchMiddleware for that.
-func ValidatorMiddleware(validator TokenValidator, apiKeyHeader string) func(http.Handler) http.Handler {
+func (vb *ValidatorBase) Middleware(apiKeyHeader string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var token string
@@ -33,7 +34,7 @@ func ValidatorMiddleware(validator TokenValidator, apiKeyHeader string) func(htt
 				return
 			}
 
-			info, err := validator.ValidateToken(r.Context(), token)
+			info, err := vb.self.ValidateToken(r.Context(), token)
 			if err != nil {
 				var denied *DeniedError
 				if errors.As(err, &denied) {

--- a/pkg/auth/inbound/middleware.go
+++ b/pkg/auth/inbound/middleware.go
@@ -11,44 +11,39 @@ import (
 	"strings"
 )
 
-// Middleware returns an HTTP middleware that validates inbound Bearer tokens
-// (or API keys when apiKeyHeader is non-empty).
-// It extracts the token, calls ValidateToken on the embedded validator, and stores
-// the resulting TokenInfo in the request context.
-// It does NOT implement per-tool auth bypass — use DispatchMiddleware for that.
-func (vb *ValidatorBase) Middleware(apiKeyHeader string) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var token string
-			if apiKeyHeader != "" {
-				token = r.Header.Get(apiKeyHeader)
-			} else {
-				authHeader := r.Header.Get("Authorization")
-				if after, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
-					token = strings.TrimSpace(after)
-				}
-			}
-
-			if token == "" {
-				writeUnauthorized(w, r, "missing_token")
-				return
-			}
-
-			info, err := vb.self.ValidateToken(r.Context(), token)
-			if err != nil {
-				var denied *DeniedError
-				if errors.As(err, &denied) {
-					writeDenied(w, r, denied)
-				} else {
-					writeUnauthorized(w, r, "invalid_token")
-				}
-				return
-			}
-
-			ctx := context.WithValue(r.Context(), contextKey{}, info)
-			next.ServeHTTP(w, r.WithContext(ctx))
-		})
+// ExtractBearerToken returns the Bearer token from the Authorization header,
+// or empty string if not present or malformed.
+func ExtractBearerToken(r *http.Request) string {
+	authHeader := r.Header.Get("Authorization")
+	after, ok := strings.CutPrefix(authHeader, "Bearer ")
+	if !ok {
+		return ""
 	}
+	return strings.TrimSpace(after)
+}
+
+// ServeValidated validates token via v, writes an error response on failure,
+// or stores TokenInfo in context and calls next on success.
+// Sub-packages call this to implement their Wrap method.
+func ServeValidated(w http.ResponseWriter, r *http.Request, next http.Handler, v TokenValidator, token string) {
+	if token == "" {
+		writeUnauthorized(w, r, "missing_token")
+		return
+	}
+
+	info, err := v.ValidateToken(r.Context(), token)
+	if err != nil {
+		var denied *DeniedError
+		if errors.As(err, &denied) {
+			writeDenied(w, r, denied)
+		} else {
+			writeUnauthorized(w, r, "invalid_token")
+		}
+		return
+	}
+
+	ctx := context.WithValue(r.Context(), contextKey{}, info)
+	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // DispatchMiddleware builds a middleware that:
@@ -61,17 +56,17 @@ func (vb *ValidatorBase) Middleware(apiKeyHeader string) func(http.Handler) http
 // registry is used to check whether auth is required for a given tool.
 // upstreamLookup maps a tool name to its upstream name; may be nil when overrides is empty.
 func DispatchMiddleware(
-	globalMW func(http.Handler) http.Handler,
-	overrides map[string]func(http.Handler) http.Handler,
+	globalMW Middleware,
+	overrides map[string]Middleware,
 	registry RegistryReader,
 	upstreamLookup func(string) string,
-) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
+) Middleware {
+	return MiddlewareFunc(func(next http.Handler) http.Handler {
 		// Pre-compute handlers to avoid allocating a new wrapper per request.
-		globalH := globalMW(next)
+		globalH := globalMW.Wrap(next)
 		overrideHandlers := make(map[string]http.Handler, len(overrides))
 		for upstreamName, mw := range overrides {
-			overrideHandlers[upstreamName] = mw(next)
+			overrideHandlers[upstreamName] = mw.Wrap(next)
 		}
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -97,7 +92,7 @@ func DispatchMiddleware(
 
 			globalH.ServeHTTP(w, r)
 		})
-	}
+	})
 }
 
 // peekToolCallName reads the request body, attempts to parse a JSON-RPC tools/call message,

--- a/pkg/auth/inbound/middleware.go
+++ b/pkg/auth/inbound/middleware.go
@@ -24,7 +24,7 @@ func ExtractBearerToken(r *http.Request) string {
 
 // ServeValidated validates token via v, writes an error response on failure,
 // or stores TokenInfo in context and calls next on success.
-// Sub-packages call this to implement their Wrap method.
+// Sub-packages call this to implement their ServeHTTP method.
 func ServeValidated(w http.ResponseWriter, r *http.Request, next http.Handler, v TokenValidator, token string) {
 	if token == "" {
 		writeUnauthorized(w, r, "missing_token")
@@ -46,53 +46,64 @@ func ServeValidated(w http.ResponseWriter, r *http.Request, next http.Handler, v
 	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
-// DispatchMiddleware builds a middleware that:
+// dispatchHandler implements http.Handler. It routes each request to the
+// appropriate inbound auth handler based on per-tool configuration.
+type dispatchHandler struct {
+	globalH   http.Handler
+	overrides map[string]http.Handler
+	registry  RegistryReader
+	lookup    func(string) string
+	bypass    http.Handler
+}
+
+// NewDispatchHandler builds an http.Handler that:
 //  1. Peeks at the request body to detect tools/call with per-tool auth bypass.
-//  2. Routes to the per-upstream override middleware when one is configured, falling
-//     back to globalMW for all other tools.
+//  2. Routes to the per-upstream override handler when one is configured,
+//     falling back to globalH for all other tools.
 //
-// globalMW is the middleware used when no per-upstream override applies.
-// overrides maps upstream names to their specific validator middlewares.
+// globalH is the handler used when no per-upstream override applies.
+// overrides maps upstream names to their specific auth handlers (each already wired to bypass).
 // registry is used to check whether auth is required for a given tool.
 // upstreamLookup maps a tool name to its upstream name; may be nil when overrides is empty.
-func DispatchMiddleware(
-	globalMW Middleware,
-	overrides map[string]Middleware,
+// bypass is the inner MCP handler used when auth is skipped for a public tool.
+func NewDispatchHandler(
+	globalH http.Handler,
+	overrides map[string]http.Handler,
 	registry RegistryReader,
 	upstreamLookup func(string) string,
-) Middleware {
-	return MiddlewareFunc(func(next http.Handler) http.Handler {
-		// Pre-compute handlers to avoid allocating a new wrapper per request.
-		globalH := globalMW.Wrap(next)
-		overrideHandlers := make(map[string]http.Handler, len(overrides))
-		for upstreamName, mw := range overrides {
-			overrideHandlers[upstreamName] = mw.Wrap(next)
+	bypass http.Handler,
+) http.Handler {
+	return &dispatchHandler{
+		globalH:   globalH,
+		overrides: overrides,
+		registry:  registry,
+		lookup:    upstreamLookup,
+		bypass:    bypass,
+	}
+}
+
+func (d *dispatchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	toolName, isToolCall, body := peekToolCallName(r)
+	if body != nil {
+		r.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	// Per-operation bypass: tool explicitly marked as public.
+	if isToolCall && !d.registry.AuthRequired(toolName) {
+		d.bypass.ServeHTTP(w, r)
+		return
+	}
+
+	// Route to per-upstream override when configured.
+	if d.lookup != nil && toolName != "" && len(d.overrides) > 0 {
+		upstreamName := d.lookup(toolName)
+		if h, ok := d.overrides[upstreamName]; ok {
+			h.ServeHTTP(w, r)
+			return
 		}
+	}
 
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			toolName, isToolCall, body := peekToolCallName(r)
-			if body != nil {
-				r.Body = io.NopCloser(bytes.NewReader(body))
-			}
-
-			// Per-operation bypass: tool explicitly marked as public.
-			if isToolCall && !registry.AuthRequired(toolName) {
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			// Route to per-upstream override when configured.
-			if upstreamLookup != nil && toolName != "" && len(overrideHandlers) > 0 {
-				upstreamName := upstreamLookup(toolName)
-				if h, ok := overrideHandlers[upstreamName]; ok {
-					h.ServeHTTP(w, r)
-					return
-				}
-			}
-
-			globalH.ServeHTTP(w, r)
-		})
-	})
+	d.globalH.ServeHTTP(w, r)
 }
 
 // peekToolCallName reads the request body, attempts to parse a JSON-RPC tools/call message,

--- a/pkg/auth/inbound/middleware.go
+++ b/pkg/auth/inbound/middleware.go
@@ -2,9 +2,7 @@ package inbound
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,30 +18,6 @@ func ExtractBearerToken(r *http.Request) string {
 		return ""
 	}
 	return strings.TrimSpace(after)
-}
-
-// ServeValidated validates token via v, writes an error response on failure,
-// or stores TokenInfo in context and calls next on success.
-// Sub-packages call this to implement their ServeHTTP method.
-func ServeValidated(w http.ResponseWriter, r *http.Request, next http.Handler, v TokenValidator, token string) {
-	if token == "" {
-		writeUnauthorized(w, r, "missing_token")
-		return
-	}
-
-	info, err := v.ValidateToken(r.Context(), token)
-	if err != nil {
-		var denied *DeniedError
-		if errors.As(err, &denied) {
-			writeDenied(w, r, denied)
-		} else {
-			writeUnauthorized(w, r, "invalid_token")
-		}
-		return
-	}
-
-	ctx := context.WithValue(r.Context(), contextKey{}, info)
-	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // dispatchHandler implements http.Handler. It routes each request to the
@@ -134,8 +108,8 @@ func peekToolCallName(r *http.Request) (toolName string, isToolCall bool, body [
 	return msg.Params.Name, true, body
 }
 
-// writeUnauthorized writes an HTTP 401 response with the appropriate WWW-Authenticate header.
-func writeUnauthorized(w http.ResponseWriter, r *http.Request, errCode string) {
+// WriteUnauthorized writes an HTTP 401 response with the appropriate WWW-Authenticate header.
+func WriteUnauthorized(w http.ResponseWriter, r *http.Request, errCode string) {
 	metadataURL := resourceMetadataURL(r)
 	wwwAuth := fmt.Sprintf(
 		`Bearer realm="mcp-anything", error=%q, resource_metadata=%q`,
@@ -152,15 +126,15 @@ func writeUnauthorized(w http.ResponseWriter, r *http.Request, errCode string) {
 	_, _ = w.Write(resp)
 }
 
-// writeDenied writes an HTTP response for an explicit denial with a specific status code.
-// If the status is 401, it delegates to writeUnauthorized to preserve WWW-Authenticate semantics.
-func writeDenied(w http.ResponseWriter, r *http.Request, denied *DeniedError) {
+// WriteDenied writes an HTTP response for an explicit denial with a specific status code.
+// If the status is 401, it delegates to WriteUnauthorized to preserve WWW-Authenticate semantics.
+func WriteDenied(w http.ResponseWriter, r *http.Request, denied *DeniedError) {
 	if denied.Status == 0 || denied.Status == http.StatusUnauthorized {
 		errCode := denied.Message
 		if errCode == "" {
 			errCode = "access_denied"
 		}
-		writeUnauthorized(w, r, errCode)
+		WriteUnauthorized(w, r, errCode)
 		return
 	}
 	errCode := denied.Message

--- a/pkg/auth/outbound/apikey/apikey.go
+++ b/pkg/auth/outbound/apikey/apikey.go
@@ -19,7 +19,10 @@ func init() {
 		if !ok {
 			return nil, fmt.Errorf("outbound/api_key: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		return NewProvider(oc.APIKey).Wrap, nil
+		p := NewProvider(oc.APIKey)
+		return func(next http.Handler) http.Handler {
+			return &Provider{header: p.header, valueEnv: p.valueEnv, prefix: p.prefix, Next: next}
+		}, nil
 	})
 }
 
@@ -28,6 +31,7 @@ type Provider struct {
 	header   string
 	valueEnv string
 	prefix   string
+	Next     http.Handler
 }
 
 // NewProvider creates a Provider from config.
@@ -53,9 +57,7 @@ func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) {
 	return map[string]string{p.header: p.prefix + val}, nil
 }
 
-// Wrap implements outbound.Middleware. It injects an API key header into the request context.
-func (p *Provider) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		outbound.ServeWithProvider(w, r, next, p)
-	})
+// ServeHTTP implements http.Handler. It injects an API key header into the request context.
+func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	outbound.ServeWithProvider(w, r, p.Next, p)
 }

--- a/pkg/auth/outbound/apikey/apikey.go
+++ b/pkg/auth/outbound/apikey/apikey.go
@@ -19,12 +19,13 @@ func init() {
 		if !ok {
 			return nil, fmt.Errorf("outbound/api_key: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		return outbound.Middleware(NewProvider(oc.APIKey)), nil
+		return NewProvider(oc.APIKey).Middleware(), nil
 	})
 }
 
 // Provider injects an API key into a configured request header.
 type Provider struct {
+	outbound.ProviderBase
 	header   string
 	valueEnv string
 	prefix   string
@@ -32,11 +33,13 @@ type Provider struct {
 
 // NewProvider creates a Provider from config.
 func NewProvider(cfg config.APIKeyOutboundConfig) *Provider {
-	return &Provider{
+	p := &Provider{
 		header:   cfg.Header,
 		valueEnv: cfg.ValueEnv,
 		prefix:   cfg.Prefix,
 	}
+	p.ProviderBase = outbound.NewProviderBase(p)
+	return p
 }
 
 // Token returns empty string because API key auth uses RawHeaders().

--- a/pkg/auth/outbound/apikey/apikey.go
+++ b/pkg/auth/outbound/apikey/apikey.go
@@ -19,13 +19,12 @@ func init() {
 		if !ok {
 			return nil, fmt.Errorf("outbound/api_key: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		return NewProvider(oc.APIKey).Middleware(), nil
+		return NewProvider(oc.APIKey).Wrap, nil
 	})
 }
 
 // Provider injects an API key into a configured request header.
 type Provider struct {
-	outbound.ProviderBase
 	header   string
 	valueEnv string
 	prefix   string
@@ -33,13 +32,11 @@ type Provider struct {
 
 // NewProvider creates a Provider from config.
 func NewProvider(cfg config.APIKeyOutboundConfig) *Provider {
-	p := &Provider{
+	return &Provider{
 		header:   cfg.Header,
 		valueEnv: cfg.ValueEnv,
 		prefix:   cfg.Prefix,
 	}
-	p.ProviderBase = outbound.NewProviderBase(p)
-	return p
 }
 
 // Token returns empty string because API key auth uses RawHeaders().
@@ -54,4 +51,11 @@ func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) {
 		return nil, fmt.Errorf("outbound API key env var %q is empty or unset", p.valueEnv)
 	}
 	return map[string]string{p.header: p.prefix + val}, nil
+}
+
+// Wrap implements outbound.Middleware. It injects an API key header into the request context.
+func (p *Provider) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		outbound.ServeWithProvider(w, r, next, p)
+	})
 }

--- a/pkg/auth/outbound/apikey/apikey.go
+++ b/pkg/auth/outbound/apikey/apikey.go
@@ -14,15 +14,12 @@ import (
 )
 
 func init() {
-	pkgmiddleware.Register("outbound/api_key", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
+	pkgmiddleware.Register("outbound/api_key", func(_ context.Context, cfg any) (pkgmiddleware.Builder, error) {
 		oc, ok := cfg.(*config.OutboundAuthConfig)
 		if !ok {
 			return nil, fmt.Errorf("outbound/api_key: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		p := NewProvider(oc.APIKey)
-		return func(next http.Handler) http.Handler {
-			return &Provider{header: p.header, valueEnv: p.valueEnv, prefix: p.prefix, Next: next}
-		}, nil
+		return NewProvider(oc.APIKey), nil
 	})
 }
 
@@ -43,6 +40,11 @@ func NewProvider(cfg config.APIKeyOutboundConfig) *Provider {
 	}
 }
 
+// Build implements middleware.Builder. It returns a Provider wired to next.
+func (p *Provider) Build(next http.Handler) http.Handler {
+	return &Provider{header: p.header, valueEnv: p.valueEnv, prefix: p.prefix, Next: next}
+}
+
 // Token returns empty string because API key auth uses RawHeaders().
 func (p *Provider) Token(_ context.Context) (string, error) {
 	return "", nil
@@ -59,5 +61,14 @@ func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) {
 
 // ServeHTTP implements http.Handler. It injects an API key header into the request context.
 func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	outbound.ServeWithProvider(w, r, p.Next, p)
+	ctx := r.Context()
+	rawHeaders, err := p.RawHeaders(ctx)
+	if err != nil {
+		p.Next.ServeHTTP(w, r.WithContext(outbound.WithAuthResult(ctx, outbound.AuthErrResult(err))))
+		return
+	}
+	if len(rawHeaders) > 0 {
+		ctx = outbound.WithHeaders(ctx, rawHeaders)
+	}
+	p.Next.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/pkg/auth/outbound/bearer/bearer.go
+++ b/pkg/auth/outbound/bearer/bearer.go
@@ -19,21 +19,18 @@ func init() {
 		if !ok {
 			return nil, fmt.Errorf("outbound/bearer: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		return NewProvider(oc.Bearer).Middleware(), nil
+		return NewProvider(oc.Bearer).Wrap, nil
 	})
 }
 
 // Provider injects a static Bearer token read from an environment variable.
 type Provider struct {
-	outbound.ProviderBase
 	tokenEnv string
 }
 
 // NewProvider creates a Provider from config.
 func NewProvider(cfg config.BearerOutboundConfig) *Provider {
-	p := &Provider{tokenEnv: cfg.TokenEnv}
-	p.ProviderBase = outbound.NewProviderBase(p)
-	return p
+	return &Provider{tokenEnv: cfg.TokenEnv}
 }
 
 // Token returns the Bearer token value from the configured environment variable.
@@ -48,4 +45,11 @@ func (p *Provider) Token(_ context.Context) (string, error) {
 // RawHeaders returns nil because bearer auth uses Token().
 func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) {
 	return nil, nil
+}
+
+// Wrap implements outbound.Middleware. It injects a Bearer token into the request context.
+func (p *Provider) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		outbound.ServeWithProvider(w, r, next, p)
+	})
 }

--- a/pkg/auth/outbound/bearer/bearer.go
+++ b/pkg/auth/outbound/bearer/bearer.go
@@ -19,18 +19,21 @@ func init() {
 		if !ok {
 			return nil, fmt.Errorf("outbound/bearer: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		return outbound.Middleware(NewProvider(oc.Bearer)), nil
+		return NewProvider(oc.Bearer).Middleware(), nil
 	})
 }
 
 // Provider injects a static Bearer token read from an environment variable.
 type Provider struct {
+	outbound.ProviderBase
 	tokenEnv string
 }
 
 // NewProvider creates a Provider from config.
 func NewProvider(cfg config.BearerOutboundConfig) *Provider {
-	return &Provider{tokenEnv: cfg.TokenEnv}
+	p := &Provider{tokenEnv: cfg.TokenEnv}
+	p.ProviderBase = outbound.NewProviderBase(p)
+	return p
 }
 
 // Token returns the Bearer token value from the configured environment variable.

--- a/pkg/auth/outbound/bearer/bearer.go
+++ b/pkg/auth/outbound/bearer/bearer.go
@@ -19,13 +19,17 @@ func init() {
 		if !ok {
 			return nil, fmt.Errorf("outbound/bearer: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		return NewProvider(oc.Bearer).Wrap, nil
+		p := NewProvider(oc.Bearer)
+		return func(next http.Handler) http.Handler {
+			return &Provider{tokenEnv: p.tokenEnv, Next: next}
+		}, nil
 	})
 }
 
 // Provider injects a static Bearer token read from an environment variable.
 type Provider struct {
 	tokenEnv string
+	Next     http.Handler
 }
 
 // NewProvider creates a Provider from config.
@@ -47,9 +51,7 @@ func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) {
 	return nil, nil
 }
 
-// Wrap implements outbound.Middleware. It injects a Bearer token into the request context.
-func (p *Provider) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		outbound.ServeWithProvider(w, r, next, p)
-	})
+// ServeHTTP implements http.Handler. It injects a Bearer token into the request context.
+func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	outbound.ServeWithProvider(w, r, p.Next, p)
 }

--- a/pkg/auth/outbound/bearer/bearer.go
+++ b/pkg/auth/outbound/bearer/bearer.go
@@ -14,15 +14,12 @@ import (
 )
 
 func init() {
-	pkgmiddleware.Register("outbound/bearer", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
+	pkgmiddleware.Register("outbound/bearer", func(_ context.Context, cfg any) (pkgmiddleware.Builder, error) {
 		oc, ok := cfg.(*config.OutboundAuthConfig)
 		if !ok {
 			return nil, fmt.Errorf("outbound/bearer: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		p := NewProvider(oc.Bearer)
-		return func(next http.Handler) http.Handler {
-			return &Provider{tokenEnv: p.tokenEnv, Next: next}
-		}, nil
+		return NewProvider(oc.Bearer), nil
 	})
 }
 
@@ -35,6 +32,11 @@ type Provider struct {
 // NewProvider creates a Provider from config.
 func NewProvider(cfg config.BearerOutboundConfig) *Provider {
 	return &Provider{tokenEnv: cfg.TokenEnv}
+}
+
+// Build implements middleware.Builder. It returns a Provider wired to next.
+func (p *Provider) Build(next http.Handler) http.Handler {
+	return &Provider{tokenEnv: p.tokenEnv, Next: next}
 }
 
 // Token returns the Bearer token value from the configured environment variable.
@@ -53,5 +55,14 @@ func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) {
 
 // ServeHTTP implements http.Handler. It injects a Bearer token into the request context.
 func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	outbound.ServeWithProvider(w, r, p.Next, p)
+	ctx := r.Context()
+	token, err := p.Token(ctx)
+	if err != nil {
+		p.Next.ServeHTTP(w, r.WithContext(outbound.WithAuthResult(ctx, outbound.AuthErrResult(err))))
+		return
+	}
+	if token != "" {
+		ctx = outbound.WithHeaders(ctx, map[string]string{"Authorization": "Bearer " + token})
+	}
+	p.Next.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/pkg/auth/outbound/context.go
+++ b/pkg/auth/outbound/context.go
@@ -20,8 +20,8 @@ func HeadersFromContext(ctx context.Context) map[string]string {
 	return h
 }
 
-// withHeaders stores outbound auth headers in ctx under the package-private outboundHeadersKey.
-func withHeaders(ctx context.Context, headers map[string]string) context.Context {
+// WithHeaders stores outbound auth headers in ctx under the package-private outboundHeadersKey.
+func WithHeaders(ctx context.Context, headers map[string]string) context.Context {
 	return context.WithValue(ctx, outboundHeadersKey{}, headers)
 }
 
@@ -33,7 +33,7 @@ func AuthResultFromContext(ctx context.Context) *sdkmcp.CallToolResult {
 	return r
 }
 
-// withAuthResult stores an early-exit result in ctx under the package-private outboundResultKey.
-func withAuthResult(ctx context.Context, result *sdkmcp.CallToolResult) context.Context {
+// WithAuthResult stores an early-exit result in ctx under the package-private outboundResultKey.
+func WithAuthResult(ctx context.Context, result *sdkmcp.CallToolResult) context.Context {
 	return context.WithValue(ctx, outboundResultKey{}, result)
 }

--- a/pkg/auth/outbound/middleware.go
+++ b/pkg/auth/outbound/middleware.go
@@ -8,9 +8,8 @@ import (
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// Middleware returns an HTTP middleware for the per-tool execution chain.
-// It resolves outbound credentials from the embedded provider and stores them in context
-// for the terminal handler.
+// ServeWithProvider resolves credentials from p and calls next with the appropriate
+// context values set. Sub-packages call this to implement their Wrap method.
 //
 // On success, auth headers are stored via withHeaders.
 // On AuthRequiredError (e.g. OAuth2 user redirect needed), a CallToolResult is stored
@@ -19,35 +18,31 @@ import (
 //
 // next is always called so that the terminal handler can write the result to the pipeline state.
 // The terminal handler must check AuthResultFromContext before proceeding with the HTTP call.
-func (pb *ProviderBase) Middleware() func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := r.Context()
+func ServeWithProvider(w http.ResponseWriter, r *http.Request, next http.Handler, p TokenProvider) {
+	ctx := r.Context()
 
-			rawHeaders, err := pb.self.RawHeaders(ctx)
-			if err != nil {
-				ctx = withAuthResult(ctx, authErrResult(err))
-				next.ServeHTTP(w, r.WithContext(ctx))
-				return
-			}
-
-			if len(rawHeaders) > 0 {
-				ctx = withHeaders(ctx, rawHeaders)
-			} else {
-				token, tokenErr := pb.self.Token(ctx)
-				if tokenErr != nil {
-					ctx = withAuthResult(ctx, authErrResult(tokenErr))
-					next.ServeHTTP(w, r.WithContext(ctx))
-					return
-				}
-				if token != "" {
-					ctx = withHeaders(ctx, map[string]string{"Authorization": "Bearer " + token})
-				}
-			}
-
-			next.ServeHTTP(w, r.WithContext(ctx))
-		})
+	rawHeaders, err := p.RawHeaders(ctx)
+	if err != nil {
+		ctx = withAuthResult(ctx, authErrResult(err))
+		next.ServeHTTP(w, r.WithContext(ctx))
+		return
 	}
+
+	if len(rawHeaders) > 0 {
+		ctx = withHeaders(ctx, rawHeaders)
+	} else {
+		token, tokenErr := p.Token(ctx)
+		if tokenErr != nil {
+			ctx = withAuthResult(ctx, authErrResult(tokenErr))
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+		if token != "" {
+			ctx = withHeaders(ctx, map[string]string{"Authorization": "Bearer " + token})
+		}
+	}
+
+	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // authErrResult converts an outbound auth error into a CallToolResult.

--- a/pkg/auth/outbound/middleware.go
+++ b/pkg/auth/outbound/middleware.go
@@ -8,8 +8,9 @@ import (
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// Middleware wraps a TokenProvider as an HTTP middleware for the per-tool execution chain.
-// It resolves outbound credentials and stores them in context for the terminal handler.
+// Middleware returns an HTTP middleware for the per-tool execution chain.
+// It resolves outbound credentials from the embedded provider and stores them in context
+// for the terminal handler.
 //
 // On success, auth headers are stored via withHeaders.
 // On AuthRequiredError (e.g. OAuth2 user redirect needed), a CallToolResult is stored
@@ -18,12 +19,12 @@ import (
 //
 // next is always called so that the terminal handler can write the result to the pipeline state.
 // The terminal handler must check AuthResultFromContext before proceeding with the HTTP call.
-func Middleware(provider TokenProvider) func(http.Handler) http.Handler {
+func (pb *ProviderBase) Middleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
-			rawHeaders, err := provider.RawHeaders(ctx)
+			rawHeaders, err := pb.self.RawHeaders(ctx)
 			if err != nil {
 				ctx = withAuthResult(ctx, authErrResult(err))
 				next.ServeHTTP(w, r.WithContext(ctx))
@@ -33,7 +34,7 @@ func Middleware(provider TokenProvider) func(http.Handler) http.Handler {
 			if len(rawHeaders) > 0 {
 				ctx = withHeaders(ctx, rawHeaders)
 			} else {
-				token, tokenErr := provider.Token(ctx)
+				token, tokenErr := pb.self.Token(ctx)
 				if tokenErr != nil {
 					ctx = withAuthResult(ctx, authErrResult(tokenErr))
 					next.ServeHTTP(w, r.WithContext(ctx))

--- a/pkg/auth/outbound/middleware.go
+++ b/pkg/auth/outbound/middleware.go
@@ -3,51 +3,13 @@ package outbound
 import (
 	"errors"
 	"fmt"
-	"net/http"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// ServeWithProvider resolves credentials from p and calls next with the appropriate
-// context values set. Sub-packages call this to implement their Wrap method.
-//
-// On success, auth headers are stored via withHeaders.
-// On AuthRequiredError (e.g. OAuth2 user redirect needed), a CallToolResult is stored
-// via withAuthResult so the terminal handler can return it without making an upstream call.
-// On any other error, an error CallToolResult is stored via withAuthResult.
-//
-// next is always called so that the terminal handler can write the result to the pipeline state.
-// The terminal handler must check AuthResultFromContext before proceeding with the HTTP call.
-func ServeWithProvider(w http.ResponseWriter, r *http.Request, next http.Handler, p TokenProvider) {
-	ctx := r.Context()
-
-	rawHeaders, err := p.RawHeaders(ctx)
-	if err != nil {
-		ctx = withAuthResult(ctx, authErrResult(err))
-		next.ServeHTTP(w, r.WithContext(ctx))
-		return
-	}
-
-	if len(rawHeaders) > 0 {
-		ctx = withHeaders(ctx, rawHeaders)
-	} else {
-		token, tokenErr := p.Token(ctx)
-		if tokenErr != nil {
-			ctx = withAuthResult(ctx, authErrResult(tokenErr))
-			next.ServeHTTP(w, r.WithContext(ctx))
-			return
-		}
-		if token != "" {
-			ctx = withHeaders(ctx, map[string]string{"Authorization": "Bearer " + token})
-		}
-	}
-
-	next.ServeHTTP(w, r.WithContext(ctx))
-}
-
-// authErrResult converts an outbound auth error into a CallToolResult.
+// AuthErrResult converts an outbound auth error into a CallToolResult.
 // AuthRequiredError produces the OAuth2 authorization redirect message.
-func authErrResult(err error) *sdkmcp.CallToolResult {
+func AuthErrResult(err error) *sdkmcp.CallToolResult {
 	var authErr *AuthRequiredError
 	if errors.As(err, &authErr) {
 		return &sdkmcp.CallToolResult{

--- a/pkg/auth/outbound/none/none.go
+++ b/pkg/auth/outbound/none/none.go
@@ -17,24 +17,25 @@ func init() {
 		if _, ok := cfg.(*config.OutboundAuthConfig); !ok {
 			return nil, fmt.Errorf("outbound/none: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		return NewProvider().Middleware(), nil
+		return NewProvider().Wrap, nil
 	})
 }
 
 // Provider is a no-op provider that adds no authentication headers.
-type Provider struct {
-	outbound.ProviderBase
-}
+type Provider struct{}
 
 // NewProvider creates a no-op Provider.
-func NewProvider() *Provider {
-	p := &Provider{}
-	p.ProviderBase = outbound.NewProviderBase(p)
-	return p
-}
+func NewProvider() *Provider { return &Provider{} }
 
 // Token returns an empty token; no authentication is injected.
 func (p *Provider) Token(_ context.Context) (string, error) { return "", nil }
 
 // RawHeaders returns nil; no authentication headers are injected.
 func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) { return nil, nil }
+
+// Wrap implements outbound.Middleware. It passes through to next with no credential injection.
+func (p *Provider) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		outbound.ServeWithProvider(w, r, next, p)
+	})
+}

--- a/pkg/auth/outbound/none/none.go
+++ b/pkg/auth/outbound/none/none.go
@@ -17,12 +17,21 @@ func init() {
 		if _, ok := cfg.(*config.OutboundAuthConfig); !ok {
 			return nil, fmt.Errorf("outbound/none: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		return outbound.Middleware(&Provider{}), nil
+		return NewProvider().Middleware(), nil
 	})
 }
 
 // Provider is a no-op provider that adds no authentication headers.
-type Provider struct{}
+type Provider struct {
+	outbound.ProviderBase
+}
+
+// NewProvider creates a no-op Provider.
+func NewProvider() *Provider {
+	p := &Provider{}
+	p.ProviderBase = outbound.NewProviderBase(p)
+	return p
+}
 
 // Token returns an empty token; no authentication is injected.
 func (p *Provider) Token(_ context.Context) (string, error) { return "", nil }

--- a/pkg/auth/outbound/none/none.go
+++ b/pkg/auth/outbound/none/none.go
@@ -7,19 +7,16 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gaarutyunov/mcp-anything/pkg/auth/outbound"
 	"github.com/gaarutyunov/mcp-anything/pkg/config"
 	pkgmiddleware "github.com/gaarutyunov/mcp-anything/pkg/middleware"
 )
 
 func init() {
-	pkgmiddleware.Register("outbound/none", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
+	pkgmiddleware.Register("outbound/none", func(_ context.Context, cfg any) (pkgmiddleware.Builder, error) {
 		if _, ok := cfg.(*config.OutboundAuthConfig); !ok {
 			return nil, fmt.Errorf("outbound/none: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		return func(next http.Handler) http.Handler {
-			return &Provider{Next: next}
-		}, nil
+		return NewProvider(), nil
 	})
 }
 
@@ -31,6 +28,11 @@ type Provider struct {
 // NewProvider creates a no-op Provider.
 func NewProvider() *Provider { return &Provider{} }
 
+// Build implements middleware.Builder. It returns a Provider wired to next.
+func (p *Provider) Build(next http.Handler) http.Handler {
+	return &Provider{Next: next}
+}
+
 // Token returns an empty token; no authentication is injected.
 func (p *Provider) Token(_ context.Context) (string, error) { return "", nil }
 
@@ -39,5 +41,5 @@ func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) { re
 
 // ServeHTTP implements http.Handler. It passes through to Next with no credential injection.
 func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	outbound.ServeWithProvider(w, r, p.Next, p)
+	p.Next.ServeHTTP(w, r)
 }

--- a/pkg/auth/outbound/none/none.go
+++ b/pkg/auth/outbound/none/none.go
@@ -17,12 +17,16 @@ func init() {
 		if _, ok := cfg.(*config.OutboundAuthConfig); !ok {
 			return nil, fmt.Errorf("outbound/none: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		return NewProvider().Wrap, nil
+		return func(next http.Handler) http.Handler {
+			return &Provider{Next: next}
+		}, nil
 	})
 }
 
 // Provider is a no-op provider that adds no authentication headers.
-type Provider struct{}
+type Provider struct {
+	Next http.Handler
+}
 
 // NewProvider creates a no-op Provider.
 func NewProvider() *Provider { return &Provider{} }
@@ -33,9 +37,7 @@ func (p *Provider) Token(_ context.Context) (string, error) { return "", nil }
 // RawHeaders returns nil; no authentication headers are injected.
 func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) { return nil, nil }
 
-// Wrap implements outbound.Middleware. It passes through to next with no credential injection.
-func (p *Provider) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		outbound.ServeWithProvider(w, r, next, p)
-	})
+// ServeHTTP implements http.Handler. It passes through to Next with no credential injection.
+func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	outbound.ServeWithProvider(w, r, p.Next, p)
 }

--- a/pkg/auth/outbound/oauth2/oauth2.go
+++ b/pkg/auth/outbound/oauth2/oauth2.go
@@ -26,14 +26,17 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return p.Wrap, nil
+		return func(next http.Handler) http.Handler {
+			return &Provider{src: p.src, Next: next}
+		}, nil
 	})
 }
 
 // Provider obtains tokens via the OAuth2 client credentials flow.
 // It caches the token and refreshes it automatically before expiry.
 type Provider struct {
-	src gooauth2.TokenSource
+	src  gooauth2.TokenSource
+	Next http.Handler
 }
 
 // NewProvider creates a Provider configured for the client credentials flow.
@@ -63,9 +66,7 @@ func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) {
 	return nil, nil
 }
 
-// Wrap implements outbound.Middleware. It injects an OAuth2 access token into the request context.
-func (p *Provider) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		outbound.ServeWithProvider(w, r, next, p)
-	})
+// ServeHTTP implements http.Handler. It injects an OAuth2 access token into the request context.
+func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	outbound.ServeWithProvider(w, r, p.Next, p)
 }

--- a/pkg/auth/outbound/oauth2/oauth2.go
+++ b/pkg/auth/outbound/oauth2/oauth2.go
@@ -26,13 +26,14 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return outbound.Middleware(p), nil
+		return p.Middleware(), nil
 	})
 }
 
 // Provider obtains tokens via the OAuth2 client credentials flow.
 // It caches the token and refreshes it automatically before expiry.
 type Provider struct {
+	outbound.ProviderBase
 	src gooauth2.TokenSource
 }
 
@@ -46,7 +47,9 @@ func NewProvider(ctx context.Context, cfg config.OAuth2CCConfig) (*Provider, err
 		Scopes:       cfg.Scopes,
 	}
 	src := gooauth2.ReuseTokenSource(nil, ccCfg.TokenSource(ctx))
-	return &Provider{src: src}, nil
+	p := &Provider{src: src}
+	p.ProviderBase = outbound.NewProviderBase(p)
+	return p, nil
 }
 
 // Token returns a valid access token, refreshing if the cached token has expired.

--- a/pkg/auth/outbound/oauth2/oauth2.go
+++ b/pkg/auth/outbound/oauth2/oauth2.go
@@ -26,14 +26,13 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return p.Middleware(), nil
+		return p.Wrap, nil
 	})
 }
 
 // Provider obtains tokens via the OAuth2 client credentials flow.
 // It caches the token and refreshes it automatically before expiry.
 type Provider struct {
-	outbound.ProviderBase
 	src gooauth2.TokenSource
 }
 
@@ -47,9 +46,7 @@ func NewProvider(ctx context.Context, cfg config.OAuth2CCConfig) (*Provider, err
 		Scopes:       cfg.Scopes,
 	}
 	src := gooauth2.ReuseTokenSource(nil, ccCfg.TokenSource(ctx))
-	p := &Provider{src: src}
-	p.ProviderBase = outbound.NewProviderBase(p)
-	return p, nil
+	return &Provider{src: src}, nil
 }
 
 // Token returns a valid access token, refreshing if the cached token has expired.
@@ -64,4 +61,11 @@ func (p *Provider) Token(_ context.Context) (string, error) {
 // RawHeaders returns nil because OAuth2 auth uses Token().
 func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) {
 	return nil, nil
+}
+
+// Wrap implements outbound.Middleware. It injects an OAuth2 access token into the request context.
+func (p *Provider) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		outbound.ServeWithProvider(w, r, next, p)
+	})
 }

--- a/pkg/auth/outbound/oauth2/oauth2.go
+++ b/pkg/auth/outbound/oauth2/oauth2.go
@@ -17,18 +17,12 @@ import (
 )
 
 func init() {
-	pkgmiddleware.Register("outbound/oauth2_client_credentials", func(ctx context.Context, cfg any) (func(http.Handler) http.Handler, error) {
+	pkgmiddleware.Register("outbound/oauth2_client_credentials", func(ctx context.Context, cfg any) (pkgmiddleware.Builder, error) {
 		oc, ok := cfg.(*config.OutboundAuthConfig)
 		if !ok {
 			return nil, fmt.Errorf("outbound/oauth2_client_credentials: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		p, err := NewProvider(ctx, oc.OAuth2ClientCredentials)
-		if err != nil {
-			return nil, err
-		}
-		return func(next http.Handler) http.Handler {
-			return &Provider{src: p.src, Next: next}
-		}, nil
+		return NewProvider(ctx, oc.OAuth2ClientCredentials)
 	})
 }
 
@@ -52,6 +46,11 @@ func NewProvider(ctx context.Context, cfg config.OAuth2CCConfig) (*Provider, err
 	return &Provider{src: src}, nil
 }
 
+// Build implements middleware.Builder. It returns a Provider wired to next, sharing the token source.
+func (p *Provider) Build(next http.Handler) http.Handler {
+	return &Provider{src: p.src, Next: next}
+}
+
 // Token returns a valid access token, refreshing if the cached token has expired.
 func (p *Provider) Token(_ context.Context) (string, error) {
 	tok, err := p.src.Token()
@@ -68,5 +67,14 @@ func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) {
 
 // ServeHTTP implements http.Handler. It injects an OAuth2 access token into the request context.
 func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	outbound.ServeWithProvider(w, r, p.Next, p)
+	ctx := r.Context()
+	token, err := p.Token(ctx)
+	if err != nil {
+		p.Next.ServeHTTP(w, r.WithContext(outbound.WithAuthResult(ctx, outbound.AuthErrResult(err))))
+		return
+	}
+	if token != "" {
+		ctx = outbound.WithHeaders(ctx, map[string]string{"Authorization": "Bearer " + token})
+	}
+	p.Next.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/pkg/auth/outbound/oauth2usersession/oauth2usersession.go
+++ b/pkg/auth/outbound/oauth2usersession/oauth2usersession.go
@@ -24,25 +24,12 @@ import (
 )
 
 func init() {
-	pkgmiddleware.Register("outbound/oauth2_user_session", func(ctx context.Context, cfg any) (func(http.Handler) http.Handler, error) {
+	pkgmiddleware.Register("outbound/oauth2_user_session", func(ctx context.Context, cfg any) (pkgmiddleware.Builder, error) {
 		oc, ok := cfg.(*config.OutboundAuthConfig)
 		if !ok {
 			return nil, fmt.Errorf("outbound/oauth2_user_session: expected *config.OutboundAuthConfig, got %T", cfg)
 		}
-		p, err := newProvider(ctx, oc)
-		if err != nil {
-			return nil, err
-		}
-		return func(next http.Handler) http.Handler {
-			return &Provider{
-				store:       p.store,
-				callbackReg: p.callbackReg,
-				upstream:    p.upstream,
-				oauth2Cfg:   p.oauth2Cfg,
-				httpClient:  p.httpClient,
-				Next:        next,
-			}
-		}, nil
+		return newProvider(ctx, oc)
 	})
 }
 
@@ -166,9 +153,30 @@ func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) {
 	return nil, nil
 }
 
+// Build implements middleware.Builder. It returns a Provider wired to next, sharing session state.
+func (p *Provider) Build(next http.Handler) http.Handler {
+	return &Provider{
+		store:       p.store,
+		callbackReg: p.callbackReg,
+		upstream:    p.upstream,
+		oauth2Cfg:   p.oauth2Cfg,
+		httpClient:  p.httpClient,
+		Next:        next,
+	}
+}
+
 // ServeHTTP implements http.Handler. It injects a per-user OAuth2 access token into the request context.
 func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	outbound.ServeWithProvider(w, r, p.Next, p)
+	ctx := r.Context()
+	token, err := p.Token(ctx)
+	if err != nil {
+		p.Next.ServeHTTP(w, r.WithContext(outbound.WithAuthResult(ctx, outbound.AuthErrResult(err))))
+		return
+	}
+	if token != "" {
+		ctx = outbound.WithHeaders(ctx, map[string]string{"Authorization": "Bearer " + token})
+	}
+	p.Next.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // doRefresh exchanges the refresh token for a new access token and saves it.

--- a/pkg/auth/outbound/oauth2usersession/oauth2usersession.go
+++ b/pkg/auth/outbound/oauth2usersession/oauth2usersession.go
@@ -33,13 +33,12 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return p.Middleware(), nil
+		return p.Wrap, nil
 	})
 }
 
 // Provider implements the oauth2_user_session outbound auth strategy.
 type Provider struct {
-	outbound.ProviderBase
 	store       config.OAuthTokenStore
 	callbackReg config.OAuthCallbackRegistrar
 	upstream    string
@@ -89,15 +88,13 @@ func newProvider(ctx context.Context, cfg *config.OutboundAuthConfig) (*Provider
 		cfg.Upstream, authURL, tokenURL, ocfg.ClientID, clientSecret, ocfg.Scopes, ocfg.CallbackURL,
 	)
 
-	p := &Provider{
+	return &Provider{
 		store:       cfg.OAuthTokenStore,
 		callbackReg: cfg.OAuthCallbackReg,
 		upstream:    cfg.Upstream,
 		oauth2Cfg:   oauth2Cfg,
 		httpClient:  &http.Client{Timeout: 30 * time.Second},
-	}
-	p.ProviderBase = outbound.NewProviderBase(p)
-	return p, nil
+	}, nil
 }
 
 // Token returns the current access token for the user, refreshing or prompting OAuth flow as needed.
@@ -157,6 +154,13 @@ func (p *Provider) Token(ctx context.Context) (string, error) {
 // RawHeaders returns nil — this strategy uses Bearer token injection via Token().
 func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) {
 	return nil, nil
+}
+
+// Wrap implements outbound.Middleware. It injects a per-user OAuth2 access token into the request context.
+func (p *Provider) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		outbound.ServeWithProvider(w, r, next, p)
+	})
 }
 
 // doRefresh exchanges the refresh token for a new access token and saves it.

--- a/pkg/auth/outbound/oauth2usersession/oauth2usersession.go
+++ b/pkg/auth/outbound/oauth2usersession/oauth2usersession.go
@@ -33,12 +33,13 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return outbound.Middleware(p), nil
+		return p.Middleware(), nil
 	})
 }
 
 // Provider implements the oauth2_user_session outbound auth strategy.
 type Provider struct {
+	outbound.ProviderBase
 	store       config.OAuthTokenStore
 	callbackReg config.OAuthCallbackRegistrar
 	upstream    string
@@ -88,13 +89,15 @@ func newProvider(ctx context.Context, cfg *config.OutboundAuthConfig) (*Provider
 		cfg.Upstream, authURL, tokenURL, ocfg.ClientID, clientSecret, ocfg.Scopes, ocfg.CallbackURL,
 	)
 
-	return &Provider{
+	p := &Provider{
 		store:       cfg.OAuthTokenStore,
 		callbackReg: cfg.OAuthCallbackReg,
 		upstream:    cfg.Upstream,
 		oauth2Cfg:   oauth2Cfg,
 		httpClient:  &http.Client{Timeout: 30 * time.Second},
-	}, nil
+	}
+	p.ProviderBase = outbound.NewProviderBase(p)
+	return p, nil
 }
 
 // Token returns the current access token for the user, refreshing or prompting OAuth flow as needed.

--- a/pkg/auth/outbound/oauth2usersession/oauth2usersession.go
+++ b/pkg/auth/outbound/oauth2usersession/oauth2usersession.go
@@ -33,7 +33,16 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return p.Wrap, nil
+		return func(next http.Handler) http.Handler {
+			return &Provider{
+				store:       p.store,
+				callbackReg: p.callbackReg,
+				upstream:    p.upstream,
+				oauth2Cfg:   p.oauth2Cfg,
+				httpClient:  p.httpClient,
+				Next:        next,
+			}
+		}, nil
 	})
 }
 
@@ -44,6 +53,7 @@ type Provider struct {
 	upstream    string
 	oauth2Cfg   *oauth2.Config
 	httpClient  *http.Client
+	Next        http.Handler
 }
 
 func newProvider(ctx context.Context, cfg *config.OutboundAuthConfig) (*Provider, error) {
@@ -156,11 +166,9 @@ func (p *Provider) RawHeaders(_ context.Context) (map[string]string, error) {
 	return nil, nil
 }
 
-// Wrap implements outbound.Middleware. It injects a per-user OAuth2 access token into the request context.
-func (p *Provider) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		outbound.ServeWithProvider(w, r, next, p)
-	})
+// ServeHTTP implements http.Handler. It injects a per-user OAuth2 access token into the request context.
+func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	outbound.ServeWithProvider(w, r, p.Next, p)
 }
 
 // doRefresh exchanges the refresh token for a new access token and saves it.

--- a/pkg/auth/outbound/outbound.go
+++ b/pkg/auth/outbound/outbound.go
@@ -4,7 +4,10 @@
 // all built-in strategies.
 package outbound
 
-import "context"
+import (
+	"context"
+	"net/http"
+)
 
 // TokenProvider supplies credentials for upstream API calls.
 // Implementations must be safe for concurrent use.
@@ -32,17 +35,15 @@ func (e *AuthRequiredError) Error() string {
 	return "authorization required: visit " + e.AuthURL
 }
 
-// ProviderBase can be embedded in any concrete TokenProvider struct to provide
-// the Middleware() method directly on the struct.
-// Call NewProviderBase(p) in the constructor to wire the self-reference.
-type ProviderBase struct {
-	self TokenProvider
+// Middleware is implemented by all outbound auth providers.
+// Each concrete provider type implements Wrap directly on the struct.
+type Middleware interface {
+	Wrap(next http.Handler) http.Handler
 }
 
-// NewProviderBase creates a ProviderBase wired to p.
-// Assign the result to the embedded ProviderBase field of your concrete type:
-//
-//	p.ProviderBase = outbound.NewProviderBase(p)
-func NewProviderBase(p TokenProvider) ProviderBase {
-	return ProviderBase{self: p}
-}
+// MiddlewareFunc adapts a func(http.Handler) http.Handler to implement Middleware.
+// This mirrors the http.HandlerFunc / http.Handler pattern.
+type MiddlewareFunc func(http.Handler) http.Handler
+
+// Wrap implements Middleware.
+func (f MiddlewareFunc) Wrap(next http.Handler) http.Handler { return f(next) }

--- a/pkg/auth/outbound/outbound.go
+++ b/pkg/auth/outbound/outbound.go
@@ -6,7 +6,6 @@ package outbound
 
 import (
 	"context"
-	"net/http"
 )
 
 // TokenProvider supplies credentials for upstream API calls.
@@ -34,16 +33,3 @@ type AuthRequiredError struct {
 func (e *AuthRequiredError) Error() string {
 	return "authorization required: visit " + e.AuthURL
 }
-
-// Middleware is implemented by all outbound auth providers.
-// Each concrete provider type implements Wrap directly on the struct.
-type Middleware interface {
-	Wrap(next http.Handler) http.Handler
-}
-
-// MiddlewareFunc adapts a func(http.Handler) http.Handler to implement Middleware.
-// This mirrors the http.HandlerFunc / http.Handler pattern.
-type MiddlewareFunc func(http.Handler) http.Handler
-
-// Wrap implements Middleware.
-func (f MiddlewareFunc) Wrap(next http.Handler) http.Handler { return f(next) }

--- a/pkg/auth/outbound/outbound.go
+++ b/pkg/auth/outbound/outbound.go
@@ -31,3 +31,18 @@ type AuthRequiredError struct {
 func (e *AuthRequiredError) Error() string {
 	return "authorization required: visit " + e.AuthURL
 }
+
+// ProviderBase can be embedded in any concrete TokenProvider struct to provide
+// the Middleware() method directly on the struct.
+// Call NewProviderBase(p) in the constructor to wire the self-reference.
+type ProviderBase struct {
+	self TokenProvider
+}
+
+// NewProviderBase creates a ProviderBase wired to p.
+// Assign the result to the embedded ProviderBase field of your concrete type:
+//
+//	p.ProviderBase = outbound.NewProviderBase(p)
+func NewProviderBase(p TokenProvider) ProviderBase {
+	return ProviderBase{self: p}
+}

--- a/pkg/mcpanything/proxy.go
+++ b/pkg/mcpanything/proxy.go
@@ -134,23 +134,28 @@ func New(ctx context.Context, cfg *pkgconfig.ProxyConfig, opts ...Option) (*Prox
 		}
 	}
 
-	// Build inbound auth middleware (global + per-upstream overrides).
-	authMiddleware, wellKnown, err := p.buildAuth(ctx)
+	// Build inbound auth handler factories (global + per-upstream overrides).
+	globalFn, overrideFns, wellKnown, err := p.buildAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Wrap MCP handlers with optional auth middleware and IP extraction for rate limiting.
+	// Wrap MCP handlers with optional auth and IP extraction for rate limiting.
 	rawHandlers := p.manager.HTTPHandlers()
 	mcpHandlers := make(map[string]http.Handler, len(rawHandlers))
 	for endpoint, handler := range rawHandlers {
 		h := handler
-		if authMiddleware != nil {
-			h = authMiddleware.Wrap(h)
+		if globalFn != nil {
+			globalH := globalFn(h)
+			overrideHandlers := make(map[string]http.Handler, len(overrideFns))
+			for name, fn := range overrideFns {
+				overrideHandlers[name] = fn(h)
+			}
+			h = pkginbound.NewDispatchHandler(globalH, overrideHandlers, p.manager, p.manager.ToolUpstreamName, h)
 		}
-		// Always wrap with ClientIPMiddleware so that source: ip rate limits work
-		// even when no auth is configured. Middleware is lightweight (single header read).
-		h = pkgratelimit.ClientIPMiddleware(h)
+		// Always add ClientIPHandler so that source: ip rate limits work
+		// even when no auth is configured. Handler is lightweight (single header read).
+		h = &pkgratelimit.ClientIPHandler{Next: h}
 		mcpHandlers[endpoint] = h
 		slog.Info("mounted group", "endpoint", endpoint)
 	}
@@ -244,24 +249,29 @@ func (p *Proxy) Shutdown(ctx context.Context) error {
 	return firstErr
 }
 
-// buildAuth constructs the inbound auth middleware and the optional well-known
-// handler. Returns nil middleware and nil handler when auth is disabled.
-func (p *Proxy) buildAuth(ctx context.Context) (pkginbound.Middleware, http.HandlerFunc, error) {
+// buildAuth constructs the inbound auth handler factories and the optional well-known
+// handler. Returns nil factories when auth is disabled.
+func (p *Proxy) buildAuth(ctx context.Context) (
+	globalFn func(http.Handler) http.Handler,
+	overrideFns map[string]func(http.Handler) http.Handler,
+	wellKnown http.HandlerFunc,
+	err error,
+) {
 	strategy := p.cfg.InboundAuth.Strategy
 	if strategy == "" || strategy == "none" {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	authCfg := p.cfg.InboundAuth
 	authCfg.JSAuthPool = p.pools.Get("js/auth")
 	authCfg.LuaAuthPool = p.pools.Get("lua/auth")
-	globalMWFn, err := pkgmiddleware.New(ctx, "inbound/"+strategy, &authCfg)
+	globalFn, err = pkgmiddleware.New(ctx, "inbound/"+strategy, &authCfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("build inbound auth middleware: %w", err)
+		return nil, nil, nil, fmt.Errorf("build inbound auth middleware: %w", err)
 	}
 	slog.Info("inbound auth enabled", "strategy", strategy)
 
-	overrideMWs := make(map[string]pkginbound.Middleware)
+	overrideFns = make(map[string]func(http.Handler) http.Handler)
 	for i := range p.cfg.Upstreams {
 		up := &p.cfg.Upstreams[i]
 		if !up.Enabled || up.InboundAuthOverride == nil {
@@ -270,27 +280,19 @@ func (p *Proxy) buildAuth(ctx context.Context) (pkginbound.Middleware, http.Hand
 		ovCfg := *up.InboundAuthOverride
 		ovCfg.JSAuthPool = p.pools.Get("js/auth")
 		ovCfg.LuaAuthPool = p.pools.Get("lua/auth")
-		ovMWFn, ovErr := pkgmiddleware.New(ctx, "inbound/"+ovCfg.Strategy, &ovCfg)
+		ovFn, ovErr := pkgmiddleware.New(ctx, "inbound/"+ovCfg.Strategy, &ovCfg)
 		if ovErr != nil {
-			return nil, nil, fmt.Errorf("build inbound auth override for %q: %w", up.Name, ovErr)
+			return nil, nil, nil, fmt.Errorf("build inbound auth override for %q: %w", up.Name, ovErr)
 		}
-		overrideMWs[up.Name] = pkginbound.MiddlewareFunc(ovMWFn)
+		overrideFns[up.Name] = ovFn
 		slog.Info("per-upstream auth override", "upstream", up.Name, "strategy", up.InboundAuthOverride.Strategy)
 	}
 
-	authMiddleware := pkginbound.DispatchMiddleware(
-		pkginbound.MiddlewareFunc(globalMWFn),
-		overrideMWs,
-		p.manager,
-		p.manager.ToolUpstreamName,
-	)
-
-	var wellKnown http.HandlerFunc
 	if strategy == "jwt" || strategy == "introspection" {
 		wellKnown = pkginbound.WellKnownHandler(p.cfg)
 	}
 
-	return authMiddleware, wellKnown, nil
+	return globalFn, overrideFns, wellKnown, nil
 }
 
 // buildSessionStore creates the OAuth session store and callback mux when configured.

--- a/pkg/mcpanything/proxy.go
+++ b/pkg/mcpanything/proxy.go
@@ -146,7 +146,7 @@ func New(ctx context.Context, cfg *pkgconfig.ProxyConfig, opts ...Option) (*Prox
 	for endpoint, handler := range rawHandlers {
 		h := handler
 		if authMiddleware != nil {
-			h = authMiddleware(h)
+			h = authMiddleware.Wrap(h)
 		}
 		// Always wrap with ClientIPMiddleware so that source: ip rate limits work
 		// even when no auth is configured. Middleware is lightweight (single header read).
@@ -246,7 +246,7 @@ func (p *Proxy) Shutdown(ctx context.Context) error {
 
 // buildAuth constructs the inbound auth middleware and the optional well-known
 // handler. Returns nil middleware and nil handler when auth is disabled.
-func (p *Proxy) buildAuth(ctx context.Context) (func(http.Handler) http.Handler, http.HandlerFunc, error) {
+func (p *Proxy) buildAuth(ctx context.Context) (pkginbound.Middleware, http.HandlerFunc, error) {
 	strategy := p.cfg.InboundAuth.Strategy
 	if strategy == "" || strategy == "none" {
 		return nil, nil, nil
@@ -255,13 +255,13 @@ func (p *Proxy) buildAuth(ctx context.Context) (func(http.Handler) http.Handler,
 	authCfg := p.cfg.InboundAuth
 	authCfg.JSAuthPool = p.pools.Get("js/auth")
 	authCfg.LuaAuthPool = p.pools.Get("lua/auth")
-	globalMW, err := pkgmiddleware.New(ctx, "inbound/"+strategy, &authCfg)
+	globalMWFn, err := pkgmiddleware.New(ctx, "inbound/"+strategy, &authCfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("build inbound auth middleware: %w", err)
 	}
 	slog.Info("inbound auth enabled", "strategy", strategy)
 
-	overrideMWs := make(map[string]func(http.Handler) http.Handler)
+	overrideMWs := make(map[string]pkginbound.Middleware)
 	for i := range p.cfg.Upstreams {
 		up := &p.cfg.Upstreams[i]
 		if !up.Enabled || up.InboundAuthOverride == nil {
@@ -270,15 +270,20 @@ func (p *Proxy) buildAuth(ctx context.Context) (func(http.Handler) http.Handler,
 		ovCfg := *up.InboundAuthOverride
 		ovCfg.JSAuthPool = p.pools.Get("js/auth")
 		ovCfg.LuaAuthPool = p.pools.Get("lua/auth")
-		ovMW, ovErr := pkgmiddleware.New(ctx, "inbound/"+ovCfg.Strategy, &ovCfg)
+		ovMWFn, ovErr := pkgmiddleware.New(ctx, "inbound/"+ovCfg.Strategy, &ovCfg)
 		if ovErr != nil {
 			return nil, nil, fmt.Errorf("build inbound auth override for %q: %w", up.Name, ovErr)
 		}
-		overrideMWs[up.Name] = ovMW
+		overrideMWs[up.Name] = pkginbound.MiddlewareFunc(ovMWFn)
 		slog.Info("per-upstream auth override", "upstream", up.Name, "strategy", up.InboundAuthOverride.Strategy)
 	}
 
-	authMiddleware := pkginbound.DispatchMiddleware(globalMW, overrideMWs, p.manager, p.manager.ToolUpstreamName)
+	authMiddleware := pkginbound.DispatchMiddleware(
+		pkginbound.MiddlewareFunc(globalMWFn),
+		overrideMWs,
+		p.manager,
+		p.manager.ToolUpstreamName,
+	)
 
 	var wellKnown http.HandlerFunc
 	if strategy == "jwt" || strategy == "introspection" {

--- a/pkg/mcpanything/proxy.go
+++ b/pkg/mcpanything/proxy.go
@@ -134,8 +134,8 @@ func New(ctx context.Context, cfg *pkgconfig.ProxyConfig, opts ...Option) (*Prox
 		}
 	}
 
-	// Build inbound auth handler factories (global + per-upstream overrides).
-	globalFn, overrideFns, wellKnown, err := p.buildAuth(ctx)
+	// Build inbound auth middleware builders (global + per-upstream overrides).
+	globalMW, overrideMWs, wellKnown, err := p.buildAuth(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -145,11 +145,11 @@ func New(ctx context.Context, cfg *pkgconfig.ProxyConfig, opts ...Option) (*Prox
 	mcpHandlers := make(map[string]http.Handler, len(rawHandlers))
 	for endpoint, handler := range rawHandlers {
 		h := handler
-		if globalFn != nil {
-			globalH := globalFn(h)
-			overrideHandlers := make(map[string]http.Handler, len(overrideFns))
-			for name, fn := range overrideFns {
-				overrideHandlers[name] = fn(h)
+		if globalMW != nil {
+			globalH := globalMW.Build(h)
+			overrideHandlers := make(map[string]http.Handler, len(overrideMWs))
+			for name, mw := range overrideMWs {
+				overrideHandlers[name] = mw.Build(h)
 			}
 			h = pkginbound.NewDispatchHandler(globalH, overrideHandlers, p.manager, p.manager.ToolUpstreamName, h)
 		}
@@ -249,11 +249,11 @@ func (p *Proxy) Shutdown(ctx context.Context) error {
 	return firstErr
 }
 
-// buildAuth constructs the inbound auth handler factories and the optional well-known
-// handler. Returns nil factories when auth is disabled.
+// buildAuth constructs the inbound auth middleware builders and the optional well-known
+// handler. Returns nil builders when auth is disabled.
 func (p *Proxy) buildAuth(ctx context.Context) (
-	globalFn func(http.Handler) http.Handler,
-	overrideFns map[string]func(http.Handler) http.Handler,
+	globalMW pkgmiddleware.Builder,
+	overrideMWs map[string]pkgmiddleware.Builder,
 	wellKnown http.HandlerFunc,
 	err error,
 ) {
@@ -265,13 +265,13 @@ func (p *Proxy) buildAuth(ctx context.Context) (
 	authCfg := p.cfg.InboundAuth
 	authCfg.JSAuthPool = p.pools.Get("js/auth")
 	authCfg.LuaAuthPool = p.pools.Get("lua/auth")
-	globalFn, err = pkgmiddleware.New(ctx, "inbound/"+strategy, &authCfg)
+	globalMW, err = pkgmiddleware.New(ctx, "inbound/"+strategy, &authCfg)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("build inbound auth middleware: %w", err)
 	}
 	slog.Info("inbound auth enabled", "strategy", strategy)
 
-	overrideFns = make(map[string]func(http.Handler) http.Handler)
+	overrideMWs = make(map[string]pkgmiddleware.Builder)
 	for i := range p.cfg.Upstreams {
 		up := &p.cfg.Upstreams[i]
 		if !up.Enabled || up.InboundAuthOverride == nil {
@@ -280,11 +280,11 @@ func (p *Proxy) buildAuth(ctx context.Context) (
 		ovCfg := *up.InboundAuthOverride
 		ovCfg.JSAuthPool = p.pools.Get("js/auth")
 		ovCfg.LuaAuthPool = p.pools.Get("lua/auth")
-		ovFn, ovErr := pkgmiddleware.New(ctx, "inbound/"+ovCfg.Strategy, &ovCfg)
+		ovMW, ovErr := pkgmiddleware.New(ctx, "inbound/"+ovCfg.Strategy, &ovCfg)
 		if ovErr != nil {
 			return nil, nil, nil, fmt.Errorf("build inbound auth override for %q: %w", up.Name, ovErr)
 		}
-		overrideFns[up.Name] = ovFn
+		overrideMWs[up.Name] = ovMW
 		slog.Info("per-upstream auth override", "upstream", up.Name, "strategy", up.InboundAuthOverride.Strategy)
 	}
 
@@ -292,7 +292,7 @@ func (p *Proxy) buildAuth(ctx context.Context) (
 		wellKnown = pkginbound.WellKnownHandler(p.cfg)
 	}
 
-	return globalFn, overrideFns, wellKnown, nil
+	return globalMW, overrideMWs, wellKnown, nil
 }
 
 // buildSessionStore creates the OAuth session store and callback mux when configured.

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -1,23 +1,5 @@
-// Package middleware defines the canonical Middleware type for mcp-anything.
+// Package middleware defines the unified middleware registry for mcp-anything.
 // All pluggable processing stages — inbound auth, outbound auth, transforms,
-// and rate limiting — are expressed as Middleware so they can be composed
-// into a linear chain with standard net/http tooling.
+// and rate limiting — register factories here so they can be composed into
+// handler chains with standard net/http tooling.
 package middleware
-
-import "net/http"
-
-// Middleware is the standard HTTP middleware type: it wraps an http.Handler and
-// returns a new one. Middleware is applied in a linear chain; the innermost
-// handler is the tool executor.
-type Middleware func(http.Handler) http.Handler
-
-// Chain composes multiple Middleware into a single Middleware, applying them
-// left-to-right (the first Middleware is the outermost wrapper).
-func Chain(ms ...Middleware) Middleware {
-	return func(next http.Handler) http.Handler {
-		for i := len(ms) - 1; i >= 0; i-- {
-			next = ms[i](next)
-		}
-		return next
-	}
-}

--- a/pkg/middleware/registry.go
+++ b/pkg/middleware/registry.go
@@ -11,10 +11,18 @@ import (
 	"sync"
 )
 
-// Factory creates a middleware from a generic config value.
+// Builder composes a middleware with a downstream handler.
+// Build is called once per downstream handler to wire the chain.
+// Implementations share expensive internal state (e.g. token caches, compiled scripts)
+// across multiple Build calls.
+type Builder interface {
+	Build(next http.Handler) http.Handler
+}
+
+// Factory creates a Builder from a generic config value.
 // The cfg parameter is type-asserted by each factory to its own concrete type.
 // Factories are registered from init() in strategy sub-packages.
-type Factory func(ctx context.Context, cfg any) (func(http.Handler) http.Handler, error)
+type Factory func(ctx context.Context, cfg any) (Builder, error)
 
 var (
 	regMu sync.RWMutex
@@ -30,10 +38,10 @@ func Register(name string, f Factory) {
 	reg[name] = f
 }
 
-// New builds the appropriate middleware from config.
+// New builds the appropriate middleware Builder from config.
 // Returns an error for unknown names; strategy sub-packages must be imported
 // (blank import) before calling New.
-func New(ctx context.Context, name string, cfg any) (func(http.Handler) http.Handler, error) {
+func New(ctx context.Context, name string, cfg any) (Builder, error) {
 	regMu.RLock()
 	f, ok := reg[name]
 	regMu.RUnlock()

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -27,7 +27,9 @@ import (
 
 func init() {
 	pkgmiddleware.Register("ratelimit/client_ip", func(_ context.Context, _ any) (func(http.Handler) http.Handler, error) {
-		return ClientIPMiddleware, nil
+		return func(next http.Handler) http.Handler {
+			return &ClientIPHandler{Next: next}
+		}, nil
 	})
 }
 
@@ -62,14 +64,23 @@ func ClientIPFromContext(ctx context.Context) string {
 	return v
 }
 
-// ClientIPMiddleware is an HTTP middleware that extracts the client IP and stores it
+// ClientIPHandler is an http.Handler that extracts the client IP and stores it
 // in the request context so that rate limiters with source: ip can use it.
+type ClientIPHandler struct {
+	Next http.Handler
+}
+
+// ServeHTTP implements http.Handler.
+func (h *ClientIPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ip := extractClientIP(r)
+	ctx := WithClientIP(r.Context(), ip)
+	h.Next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// ClientIPMiddleware wraps next with ClientIPHandler.
+// Kept for callers that compose handlers via a func adapter.
 func ClientIPMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip := extractClientIP(r)
-		ctx := WithClientIP(r.Context(), ip)
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
+	return &ClientIPHandler{Next: next}
 }
 
 // extractClientIP returns the real client IP from the HTTP request.

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -26,10 +26,8 @@ import (
 )
 
 func init() {
-	pkgmiddleware.Register("ratelimit/client_ip", func(_ context.Context, _ any) (func(http.Handler) http.Handler, error) {
-		return func(next http.Handler) http.Handler {
-			return &ClientIPHandler{Next: next}
-		}, nil
+	pkgmiddleware.Register("ratelimit/client_ip", func(_ context.Context, _ any) (pkgmiddleware.Builder, error) {
+		return &ClientIPHandler{}, nil
 	})
 }
 
@@ -70,17 +68,16 @@ type ClientIPHandler struct {
 	Next http.Handler
 }
 
+// Build implements middleware.Builder. It returns a ClientIPHandler wired to next.
+func (h *ClientIPHandler) Build(next http.Handler) http.Handler {
+	return &ClientIPHandler{Next: next}
+}
+
 // ServeHTTP implements http.Handler.
 func (h *ClientIPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ip := extractClientIP(r)
 	ctx := WithClientIP(r.Context(), ip)
 	h.Next.ServeHTTP(w, r.WithContext(ctx))
-}
-
-// ClientIPMiddleware wraps next with ClientIPHandler.
-// Kept for callers that compose handlers via a func adapter.
-func ClientIPMiddleware(next http.Handler) http.Handler {
-	return &ClientIPHandler{Next: next}
 }
 
 // extractClientIP returns the real client IP from the HTTP request.

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -17,7 +17,7 @@ func TestClientIPMiddleware(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedIP = ratelimit.ClientIPFromContext(r.Context())
 	})
-	handler := ratelimit.ClientIPMiddleware(next)
+	handler := (&ratelimit.ClientIPHandler{}).Build(next)
 
 	tests := []struct {
 		name       string

--- a/pkg/runtime/js/js.go
+++ b/pkg/runtime/js/js.go
@@ -69,7 +69,17 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return v.Wrap, nil
+		return func(next http.Handler) http.Handler {
+			return &Validator{
+				program:     v.program,
+				timeout:     v.timeout,
+				env:         v.env,
+				scriptCache: v.scriptCache,
+				httpClient:  v.httpClient,
+				pool:        v.pool,
+				Next:        next,
+			}
+		}, nil
 	})
 	pkgmiddleware.Register("outbound/js", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
 		oc, ok := cfg.(*config.OutboundAuthConfig)
@@ -83,7 +93,18 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return p.Wrap, nil
+		return func(next http.Handler) http.Handler {
+			return &Provider{
+				upstreamName: p.upstreamName,
+				program:      p.program,
+				timeout:      p.timeout,
+				env:          p.env,
+				scriptCache:  p.scriptCache,
+				httpClient:   p.httpClient,
+				pool:         p.pool,
+				Next:         next,
+			}
+		}, nil
 	})
 }
 
@@ -150,6 +171,7 @@ type Validator struct {
 	scriptCache *scriptCache
 	httpClient  *http.Client
 	pool        config.PoolAcquirer
+	Next        http.Handler
 }
 
 // NewValidator creates a Validator by reading and pre-compiling the JS script.
@@ -178,11 +200,9 @@ func NewValidator(cfg config.JSAuthConfig, pool config.PoolAcquirer) (*Validator
 	}, nil
 }
 
-// Wrap implements inbound.Middleware. It extracts a Bearer token and validates it via JS script.
-func (v *Validator) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		inbound.ServeValidated(w, r, next, v, inbound.ExtractBearerToken(r))
-	})
+// ServeHTTP implements http.Handler. It extracts a Bearer token and validates it via JS script.
+func (v *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	inbound.ServeValidated(w, r, v.Next, v, inbound.ExtractBearerToken(r))
 }
 
 // ValidateToken runs the JS script with the token and returns identity info on success.
@@ -287,6 +307,7 @@ type Provider struct {
 	scriptCache  *scriptCache // persists across callScript invocations
 	httpClient   *http.Client
 	pool         config.PoolAcquirer
+	Next         http.Handler
 }
 
 // NewProvider creates a Provider by reading and pre-compiling the JS script.
@@ -316,11 +337,9 @@ func NewProvider(upstreamName string, cfg config.JSOutboundConfig, pool config.P
 	}, nil
 }
 
-// Wrap implements outbound.Middleware. It injects JS-script-derived credentials into the request context.
-func (p *Provider) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		outbound.ServeWithProvider(w, r, next, p)
-	})
+// ServeHTTP implements http.Handler. It injects JS-script-derived credentials into the request context.
+func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	outbound.ServeWithProvider(w, r, p.Next, p)
 }
 
 // Token returns the current Bearer token, invoking the JS script if the cache has expired.

--- a/pkg/runtime/js/js.go
+++ b/pkg/runtime/js/js.go
@@ -69,7 +69,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return v.Middleware(""), nil
+		return v.Wrap, nil
 	})
 	pkgmiddleware.Register("outbound/js", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
 		oc, ok := cfg.(*config.OutboundAuthConfig)
@@ -83,7 +83,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return p.Middleware(), nil
+		return p.Wrap, nil
 	})
 }
 
@@ -144,7 +144,6 @@ type credentialCache struct {
 // The pre-compiled program is reused across calls. The shared pool bounds
 // the maximum number of concurrent JS runtimes to prevent OOM under load.
 type Validator struct {
-	inbound.ValidatorBase
 	program     *sobek.Program
 	timeout     time.Duration
 	env         map[string]string
@@ -169,16 +168,21 @@ func NewValidator(cfg config.JSAuthConfig, pool config.PoolAcquirer) (*Validator
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
-	v := &Validator{
+	return &Validator{
 		program:     prog,
 		timeout:     timeout,
 		env:         cfg.Env,
 		scriptCache: newScriptCache(),
 		httpClient:  &http.Client{Timeout: defaultFetchTimeout},
 		pool:        pool,
-	}
-	v.ValidatorBase = inbound.NewValidatorBase(v)
-	return v, nil
+	}, nil
+}
+
+// Wrap implements inbound.Middleware. It extracts a Bearer token and validates it via JS script.
+func (v *Validator) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inbound.ServeValidated(w, r, next, v, inbound.ExtractBearerToken(r))
+	})
 }
 
 // ValidateToken runs the JS script with the token and returns identity info on success.
@@ -275,7 +279,6 @@ func parseInboundResult(result sobek.Value) (*inbound.TokenInfo, error) {
 // re-invoking the script on every request. The shared pool bounds the maximum number
 // of concurrent JS runtimes to prevent OOM under load.
 type Provider struct {
-	outbound.ProviderBase
 	upstreamName string
 	program      *sobek.Program
 	timeout      time.Duration
@@ -302,7 +305,7 @@ func NewProvider(upstreamName string, cfg config.JSOutboundConfig, pool config.P
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
-	p := &Provider{
+	return &Provider{
 		upstreamName: upstreamName,
 		program:      prog,
 		timeout:      timeout,
@@ -310,9 +313,14 @@ func NewProvider(upstreamName string, cfg config.JSOutboundConfig, pool config.P
 		scriptCache:  newScriptCache(),
 		httpClient:   &http.Client{Timeout: defaultFetchTimeout},
 		pool:         pool,
-	}
-	p.ProviderBase = outbound.NewProviderBase(p)
-	return p, nil
+	}, nil
+}
+
+// Wrap implements outbound.Middleware. It injects JS-script-derived credentials into the request context.
+func (p *Provider) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		outbound.ServeWithProvider(w, r, next, p)
+	})
 }
 
 // Token returns the current Bearer token, invoking the JS script if the cache has expired.

--- a/pkg/runtime/js/js.go
+++ b/pkg/runtime/js/js.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -57,7 +58,7 @@ func init() {
 	})
 
 	// Register inbound and outbound middleware strategies.
-	pkgmiddleware.Register("inbound/js", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
+	pkgmiddleware.Register("inbound/js", func(_ context.Context, cfg any) (pkgmiddleware.Builder, error) {
 		ic, ok := cfg.(*config.InboundAuthConfig)
 		if !ok {
 			return nil, fmt.Errorf("inbound/js: expected *config.InboundAuthConfig, got %T", cfg)
@@ -65,23 +66,9 @@ func init() {
 		if ic.JSAuthPool == nil {
 			return nil, fmt.Errorf("js inbound auth requires runtime pools; set InboundAuthConfig.JSAuthPool")
 		}
-		v, err := NewValidator(ic.JS, ic.JSAuthPool)
-		if err != nil {
-			return nil, err
-		}
-		return func(next http.Handler) http.Handler {
-			return &Validator{
-				program:     v.program,
-				timeout:     v.timeout,
-				env:         v.env,
-				scriptCache: v.scriptCache,
-				httpClient:  v.httpClient,
-				pool:        v.pool,
-				Next:        next,
-			}
-		}, nil
+		return NewValidator(ic.JS, ic.JSAuthPool)
 	})
-	pkgmiddleware.Register("outbound/js", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
+	pkgmiddleware.Register("outbound/js", func(_ context.Context, cfg any) (pkgmiddleware.Builder, error) {
 		oc, ok := cfg.(*config.OutboundAuthConfig)
 		if !ok {
 			return nil, fmt.Errorf("outbound/js: expected *config.OutboundAuthConfig, got %T", cfg)
@@ -89,22 +76,7 @@ func init() {
 		if oc.JSAuthPool == nil {
 			return nil, fmt.Errorf("js outbound auth requires runtime pools; set OutboundAuthConfig.JSAuthPool")
 		}
-		p, err := NewProvider(oc.Upstream, oc.JS, oc.JSAuthPool)
-		if err != nil {
-			return nil, err
-		}
-		return func(next http.Handler) http.Handler {
-			return &Provider{
-				upstreamName: p.upstreamName,
-				program:      p.program,
-				timeout:      p.timeout,
-				env:          p.env,
-				scriptCache:  p.scriptCache,
-				httpClient:   p.httpClient,
-				pool:         p.pool,
-				Next:         next,
-			}
-		}, nil
+		return NewProvider(oc.Upstream, oc.JS, oc.JSAuthPool)
 	})
 }
 
@@ -200,9 +172,37 @@ func NewValidator(cfg config.JSAuthConfig, pool config.PoolAcquirer) (*Validator
 	}, nil
 }
 
+// Build implements middleware.Builder. It returns a Validator wired to next, sharing compiled program and cache.
+func (v *Validator) Build(next http.Handler) http.Handler {
+	return &Validator{
+		program:     v.program,
+		timeout:     v.timeout,
+		env:         v.env,
+		scriptCache: v.scriptCache,
+		httpClient:  v.httpClient,
+		pool:        v.pool,
+		Next:        next,
+	}
+}
+
 // ServeHTTP implements http.Handler. It extracts a Bearer token and validates it via JS script.
 func (v *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	inbound.ServeValidated(w, r, v.Next, v, inbound.ExtractBearerToken(r))
+	token := inbound.ExtractBearerToken(r)
+	if token == "" {
+		inbound.WriteUnauthorized(w, r, "missing_token")
+		return
+	}
+	info, err := v.ValidateToken(r.Context(), token)
+	if err != nil {
+		var denied *inbound.DeniedError
+		if errors.As(err, &denied) {
+			inbound.WriteDenied(w, r, denied)
+		} else {
+			inbound.WriteUnauthorized(w, r, "invalid_token")
+		}
+		return
+	}
+	v.Next.ServeHTTP(w, r.WithContext(inbound.WithTokenInfo(r.Context(), info)))
 }
 
 // ValidateToken runs the JS script with the token and returns identity info on success.
@@ -337,9 +337,41 @@ func NewProvider(upstreamName string, cfg config.JSOutboundConfig, pool config.P
 	}, nil
 }
 
+// Build implements middleware.Builder. It returns a Provider wired to next, sharing compiled program and cache.
+func (p *Provider) Build(next http.Handler) http.Handler {
+	return &Provider{
+		upstreamName: p.upstreamName,
+		program:      p.program,
+		timeout:      p.timeout,
+		env:          p.env,
+		scriptCache:  p.scriptCache,
+		httpClient:   p.httpClient,
+		pool:         p.pool,
+		Next:         next,
+	}
+}
+
 // ServeHTTP implements http.Handler. It injects JS-script-derived credentials into the request context.
 func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	outbound.ServeWithProvider(w, r, p.Next, p)
+	ctx := r.Context()
+	rawHeaders, err := p.RawHeaders(ctx)
+	if err != nil {
+		p.Next.ServeHTTP(w, r.WithContext(outbound.WithAuthResult(ctx, outbound.AuthErrResult(err))))
+		return
+	}
+	if len(rawHeaders) > 0 {
+		ctx = outbound.WithHeaders(ctx, rawHeaders)
+	} else {
+		token, tokenErr := p.Token(ctx)
+		if tokenErr != nil {
+			p.Next.ServeHTTP(w, r.WithContext(outbound.WithAuthResult(ctx, outbound.AuthErrResult(tokenErr))))
+			return
+		}
+		if token != "" {
+			ctx = outbound.WithHeaders(ctx, map[string]string{"Authorization": "Bearer " + token})
+		}
+	}
+	p.Next.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // Token returns the current Bearer token, invoking the JS script if the cache has expired.

--- a/pkg/runtime/js/js.go
+++ b/pkg/runtime/js/js.go
@@ -69,7 +69,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return inbound.ValidatorMiddleware(v, ""), nil
+		return v.Middleware(""), nil
 	})
 	pkgmiddleware.Register("outbound/js", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
 		oc, ok := cfg.(*config.OutboundAuthConfig)
@@ -83,7 +83,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return outbound.Middleware(p), nil
+		return p.Middleware(), nil
 	})
 }
 
@@ -144,6 +144,7 @@ type credentialCache struct {
 // The pre-compiled program is reused across calls. The shared pool bounds
 // the maximum number of concurrent JS runtimes to prevent OOM under load.
 type Validator struct {
+	inbound.ValidatorBase
 	program     *sobek.Program
 	timeout     time.Duration
 	env         map[string]string
@@ -168,14 +169,16 @@ func NewValidator(cfg config.JSAuthConfig, pool config.PoolAcquirer) (*Validator
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
-	return &Validator{
+	v := &Validator{
 		program:     prog,
 		timeout:     timeout,
 		env:         cfg.Env,
 		scriptCache: newScriptCache(),
 		httpClient:  &http.Client{Timeout: defaultFetchTimeout},
 		pool:        pool,
-	}, nil
+	}
+	v.ValidatorBase = inbound.NewValidatorBase(v)
+	return v, nil
 }
 
 // ValidateToken runs the JS script with the token and returns identity info on success.
@@ -272,6 +275,7 @@ func parseInboundResult(result sobek.Value) (*inbound.TokenInfo, error) {
 // re-invoking the script on every request. The shared pool bounds the maximum number
 // of concurrent JS runtimes to prevent OOM under load.
 type Provider struct {
+	outbound.ProviderBase
 	upstreamName string
 	program      *sobek.Program
 	timeout      time.Duration
@@ -298,7 +302,7 @@ func NewProvider(upstreamName string, cfg config.JSOutboundConfig, pool config.P
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
-	return &Provider{
+	p := &Provider{
 		upstreamName: upstreamName,
 		program:      prog,
 		timeout:      timeout,
@@ -306,7 +310,9 @@ func NewProvider(upstreamName string, cfg config.JSOutboundConfig, pool config.P
 		scriptCache:  newScriptCache(),
 		httpClient:   &http.Client{Timeout: defaultFetchTimeout},
 		pool:         pool,
-	}, nil
+	}
+	p.ProviderBase = outbound.NewProviderBase(p)
+	return p, nil
 }
 
 // Token returns the current Bearer token, invoking the JS script if the cache has expired.

--- a/pkg/runtime/lua/lua.go
+++ b/pkg/runtime/lua/lua.go
@@ -55,7 +55,9 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return v.Wrap, nil
+		return func(next http.Handler) http.Handler {
+			return &Validator{proto: v.proto, pool: v.pool, timeout: v.timeout, Next: next}
+		}, nil
 	})
 	pkgmiddleware.Register("outbound/lua", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
 		oc, ok := cfg.(*config.OutboundAuthConfig)
@@ -69,7 +71,15 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return p.Wrap, nil
+		return func(next http.Handler) http.Handler {
+			return &Provider{
+				upstreamName: p.upstreamName,
+				proto:        p.proto,
+				pool:         p.pool,
+				timeout:      p.timeout,
+				Next:         next,
+			}
+		}, nil
 	})
 }
 
@@ -81,6 +91,7 @@ type Validator struct {
 	proto   *lua.FunctionProto
 	pool    config.PoolAcquirer
 	timeout time.Duration
+	Next    http.Handler
 }
 
 // NewValidator creates a Validator by reading and pre-compiling the Lua
@@ -110,11 +121,9 @@ func NewValidator(cfg config.LuaAuthConfig, pool config.PoolAcquirer) (*Validato
 	}, nil
 }
 
-// Wrap implements inbound.Middleware. It extracts a Bearer token and validates it via Lua script.
-func (v *Validator) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		inbound.ServeValidated(w, r, next, v, inbound.ExtractBearerToken(r))
-	})
+// ServeHTTP implements http.Handler. It extracts a Bearer token and validates it via Lua script.
+func (v *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	inbound.ServeValidated(w, r, v.Next, v, inbound.ExtractBearerToken(r))
 }
 
 // ValidateToken calls the Lua script with the token and returns identity info on success.
@@ -170,6 +179,7 @@ type Provider struct {
 	pool         config.PoolAcquirer
 	timeout      time.Duration
 	cache        providerCache
+	Next         http.Handler
 }
 
 type providerCache struct {
@@ -206,11 +216,9 @@ func NewProvider(upstreamName string, cfg config.LuaOutboundConfig, pool config.
 	}, nil
 }
 
-// Wrap implements outbound.Middleware. It injects Lua-script-derived credentials into the request context.
-func (p *Provider) Wrap(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		outbound.ServeWithProvider(w, r, next, p)
-	})
+// ServeHTTP implements http.Handler. It injects Lua-script-derived credentials into the request context.
+func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	outbound.ServeWithProvider(w, r, p.Next, p)
 }
 
 // Token returns the current token, invoking the Lua script if the cache has expired.

--- a/pkg/runtime/lua/lua.go
+++ b/pkg/runtime/lua/lua.go
@@ -55,7 +55,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return v.Middleware(""), nil
+		return v.Wrap, nil
 	})
 	pkgmiddleware.Register("outbound/lua", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
 		oc, ok := cfg.(*config.OutboundAuthConfig)
@@ -69,7 +69,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return p.Middleware(), nil
+		return p.Wrap, nil
 	})
 }
 
@@ -78,7 +78,6 @@ func init() {
 // allowed (bool), status (int), extra_headers (table), error_msg (string).
 // The shared pool bounds the maximum number of concurrent Lua runtimes to prevent OOM.
 type Validator struct {
-	inbound.ValidatorBase
 	proto   *lua.FunctionProto
 	pool    config.PoolAcquirer
 	timeout time.Duration
@@ -104,13 +103,18 @@ func NewValidator(cfg config.LuaAuthConfig, pool config.PoolAcquirer) (*Validato
 		timeout = defaultTimeout
 	}
 
-	v := &Validator{
+	return &Validator{
 		proto:   proto,
 		timeout: timeout,
 		pool:    pool,
-	}
-	v.ValidatorBase = inbound.NewValidatorBase(v)
-	return v, nil
+	}, nil
+}
+
+// Wrap implements inbound.Middleware. It extracts a Bearer token and validates it via Lua script.
+func (v *Validator) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inbound.ServeValidated(w, r, next, v, inbound.ExtractBearerToken(r))
+	})
 }
 
 // ValidateToken calls the Lua script with the token and returns identity info on success.
@@ -161,7 +165,6 @@ func (v *Validator) ValidateToken(ctx context.Context, token string) (*inbound.T
 // token (string), expiry_unix (int), raw_headers (table), error_msg (string).
 // The shared pool bounds the maximum number of concurrent Lua runtimes to prevent OOM.
 type Provider struct {
-	outbound.ProviderBase
 	upstreamName string
 	proto        *lua.FunctionProto
 	pool         config.PoolAcquirer
@@ -195,14 +198,19 @@ func NewProvider(upstreamName string, cfg config.LuaOutboundConfig, pool config.
 		timeout = defaultTimeout
 	}
 
-	p := &Provider{
+	return &Provider{
 		upstreamName: upstreamName,
 		proto:        proto,
 		timeout:      timeout,
 		pool:         pool,
-	}
-	p.ProviderBase = outbound.NewProviderBase(p)
-	return p, nil
+	}, nil
+}
+
+// Wrap implements outbound.Middleware. It injects Lua-script-derived credentials into the request context.
+func (p *Provider) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		outbound.ServeWithProvider(w, r, next, p)
+	})
 }
 
 // Token returns the current token, invoking the Lua script if the cache has expired.

--- a/pkg/runtime/lua/lua.go
+++ b/pkg/runtime/lua/lua.go
@@ -5,6 +5,7 @@ package lua
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -43,7 +44,7 @@ func init() {
 	})
 
 	// Register inbound and outbound middleware strategies.
-	pkgmiddleware.Register("inbound/lua", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
+	pkgmiddleware.Register("inbound/lua", func(_ context.Context, cfg any) (pkgmiddleware.Builder, error) {
 		ic, ok := cfg.(*config.InboundAuthConfig)
 		if !ok {
 			return nil, fmt.Errorf("inbound/lua: expected *config.InboundAuthConfig, got %T", cfg)
@@ -51,15 +52,9 @@ func init() {
 		if ic.LuaAuthPool == nil {
 			return nil, fmt.Errorf("lua inbound auth requires runtime pools; set InboundAuthConfig.LuaAuthPool")
 		}
-		v, err := NewValidator(ic.Lua, ic.LuaAuthPool)
-		if err != nil {
-			return nil, err
-		}
-		return func(next http.Handler) http.Handler {
-			return &Validator{proto: v.proto, pool: v.pool, timeout: v.timeout, Next: next}
-		}, nil
+		return NewValidator(ic.Lua, ic.LuaAuthPool)
 	})
-	pkgmiddleware.Register("outbound/lua", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
+	pkgmiddleware.Register("outbound/lua", func(_ context.Context, cfg any) (pkgmiddleware.Builder, error) {
 		oc, ok := cfg.(*config.OutboundAuthConfig)
 		if !ok {
 			return nil, fmt.Errorf("outbound/lua: expected *config.OutboundAuthConfig, got %T", cfg)
@@ -67,19 +62,7 @@ func init() {
 		if oc.LuaAuthPool == nil {
 			return nil, fmt.Errorf("lua outbound auth requires runtime pools; set OutboundAuthConfig.LuaAuthPool")
 		}
-		p, err := NewProvider(oc.Upstream, oc.Lua, oc.LuaAuthPool)
-		if err != nil {
-			return nil, err
-		}
-		return func(next http.Handler) http.Handler {
-			return &Provider{
-				upstreamName: p.upstreamName,
-				proto:        p.proto,
-				pool:         p.pool,
-				timeout:      p.timeout,
-				Next:         next,
-			}
-		}, nil
+		return NewProvider(oc.Upstream, oc.Lua, oc.LuaAuthPool)
 	})
 }
 
@@ -121,9 +104,29 @@ func NewValidator(cfg config.LuaAuthConfig, pool config.PoolAcquirer) (*Validato
 	}, nil
 }
 
+// Build implements middleware.Builder. It returns a Validator wired to next, sharing compiled bytecode.
+func (v *Validator) Build(next http.Handler) http.Handler {
+	return &Validator{proto: v.proto, pool: v.pool, timeout: v.timeout, Next: next}
+}
+
 // ServeHTTP implements http.Handler. It extracts a Bearer token and validates it via Lua script.
 func (v *Validator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	inbound.ServeValidated(w, r, v.Next, v, inbound.ExtractBearerToken(r))
+	token := inbound.ExtractBearerToken(r)
+	if token == "" {
+		inbound.WriteUnauthorized(w, r, "missing_token")
+		return
+	}
+	info, err := v.ValidateToken(r.Context(), token)
+	if err != nil {
+		var denied *inbound.DeniedError
+		if errors.As(err, &denied) {
+			inbound.WriteDenied(w, r, denied)
+		} else {
+			inbound.WriteUnauthorized(w, r, "invalid_token")
+		}
+		return
+	}
+	v.Next.ServeHTTP(w, r.WithContext(inbound.WithTokenInfo(r.Context(), info)))
 }
 
 // ValidateToken calls the Lua script with the token and returns identity info on success.
@@ -216,9 +219,38 @@ func NewProvider(upstreamName string, cfg config.LuaOutboundConfig, pool config.
 	}, nil
 }
 
+// Build implements middleware.Builder. It returns a Provider wired to next, sharing compiled bytecode and cache.
+func (p *Provider) Build(next http.Handler) http.Handler {
+	return &Provider{
+		upstreamName: p.upstreamName,
+		proto:        p.proto,
+		pool:         p.pool,
+		timeout:      p.timeout,
+		Next:         next,
+	}
+}
+
 // ServeHTTP implements http.Handler. It injects Lua-script-derived credentials into the request context.
 func (p *Provider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	outbound.ServeWithProvider(w, r, p.Next, p)
+	ctx := r.Context()
+	rawHeaders, err := p.RawHeaders(ctx)
+	if err != nil {
+		p.Next.ServeHTTP(w, r.WithContext(outbound.WithAuthResult(ctx, outbound.AuthErrResult(err))))
+		return
+	}
+	if len(rawHeaders) > 0 {
+		ctx = outbound.WithHeaders(ctx, rawHeaders)
+	} else {
+		token, tokenErr := p.Token(ctx)
+		if tokenErr != nil {
+			p.Next.ServeHTTP(w, r.WithContext(outbound.WithAuthResult(ctx, outbound.AuthErrResult(tokenErr))))
+			return
+		}
+		if token != "" {
+			ctx = outbound.WithHeaders(ctx, map[string]string{"Authorization": "Bearer " + token})
+		}
+	}
+	p.Next.ServeHTTP(w, r.WithContext(ctx))
 }
 
 // Token returns the current token, invoking the Lua script if the cache has expired.

--- a/pkg/runtime/lua/lua.go
+++ b/pkg/runtime/lua/lua.go
@@ -55,7 +55,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return inbound.ValidatorMiddleware(v, ""), nil
+		return v.Middleware(""), nil
 	})
 	pkgmiddleware.Register("outbound/lua", func(_ context.Context, cfg any) (func(http.Handler) http.Handler, error) {
 		oc, ok := cfg.(*config.OutboundAuthConfig)
@@ -69,7 +69,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return outbound.Middleware(p), nil
+		return p.Middleware(), nil
 	})
 }
 
@@ -78,6 +78,7 @@ func init() {
 // allowed (bool), status (int), extra_headers (table), error_msg (string).
 // The shared pool bounds the maximum number of concurrent Lua runtimes to prevent OOM.
 type Validator struct {
+	inbound.ValidatorBase
 	proto   *lua.FunctionProto
 	pool    config.PoolAcquirer
 	timeout time.Duration
@@ -103,11 +104,13 @@ func NewValidator(cfg config.LuaAuthConfig, pool config.PoolAcquirer) (*Validato
 		timeout = defaultTimeout
 	}
 
-	return &Validator{
+	v := &Validator{
 		proto:   proto,
 		timeout: timeout,
 		pool:    pool,
-	}, nil
+	}
+	v.ValidatorBase = inbound.NewValidatorBase(v)
+	return v, nil
 }
 
 // ValidateToken calls the Lua script with the token and returns identity info on success.
@@ -158,6 +161,7 @@ func (v *Validator) ValidateToken(ctx context.Context, token string) (*inbound.T
 // token (string), expiry_unix (int), raw_headers (table), error_msg (string).
 // The shared pool bounds the maximum number of concurrent Lua runtimes to prevent OOM.
 type Provider struct {
+	outbound.ProviderBase
 	upstreamName string
 	proto        *lua.FunctionProto
 	pool         config.PoolAcquirer
@@ -191,12 +195,14 @@ func NewProvider(upstreamName string, cfg config.LuaOutboundConfig, pool config.
 		timeout = defaultTimeout
 	}
 
-	return &Provider{
+	p := &Provider{
 		upstreamName: upstreamName,
 		proto:        proto,
 		timeout:      timeout,
 		pool:         pool,
-	}, nil
+	}
+	p.ProviderBase = outbound.NewProviderBase(p)
+	return p, nil
 }
 
 // Token returns the current token, invoking the Lua script if the cache has expired.

--- a/pkg/transform/middleware.go
+++ b/pkg/transform/middleware.go
@@ -4,26 +4,28 @@ import (
 	"net/http"
 )
 
-// RequestMiddleware returns an HTTP middleware that runs the request transform.
+// Handler is an http.Handler that runs the request transform and chains to Next.
 // It reads MCP tool arguments from context (stored via WithMCPArgs), executes
 // the request jq expression, and stores the resulting RequestEnvelope in context.
 //
-// On failure the error is stored in context via withTransformError and next is
+// On failure the error is stored in context via withTransformError and Next is
 // still called so that the terminal handler can write the error to the pipeline state.
 // The terminal handler must check TransformErrorFromContext before proceeding.
-func (c *CompiledTransforms) RequestMiddleware() func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := r.Context()
-			args := MCPArgsFromContext(ctx)
+type Handler struct {
+	Transforms *CompiledTransforms
+	Next       http.Handler
+}
 
-			envelope, err := c.RunRequest(ctx, args)
-			if err != nil {
-				next.ServeHTTP(w, r.WithContext(withTransformError(ctx, err)))
-				return
-			}
+// ServeHTTP implements http.Handler.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	args := MCPArgsFromContext(ctx)
 
-			next.ServeHTTP(w, r.WithContext(withEnvelope(ctx, envelope)))
-		})
+	envelope, err := h.Transforms.RunRequest(ctx, args)
+	if err != nil {
+		h.Next.ServeHTTP(w, r.WithContext(withTransformError(ctx, err)))
+		return
 	}
+
+	h.Next.ServeHTTP(w, r.WithContext(withEnvelope(ctx, envelope)))
 }

--- a/pkg/upstream/http/builder.go
+++ b/pkg/upstream/http/builder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gaarutyunov/mcp-anything/pkg/config"
 	pkgmiddleware "github.com/gaarutyunov/mcp-anything/pkg/middleware"
 	"github.com/gaarutyunov/mcp-anything/pkg/openapi"
+	"github.com/gaarutyunov/mcp-anything/pkg/transform"
 	pkgupstream "github.com/gaarutyunov/mcp-anything/pkg/upstream"
 )
 
@@ -104,12 +105,12 @@ func (b *Builder) Build(ctx context.Context, cfg *config.UpstreamConfig, naming 
 		executor := &Executor{entry: entry}
 		entry.Executor = executor
 
-		// Compose the per-tool middleware chain:
-		//   RequestMiddleware (transform) → outbound auth → Executor (terminal handler)
+		// Compose the per-tool handler chain:
+		//   TransformHandler → outbound auth → Executor (terminal handler)
 		var h nethttp.Handler = executor
 		h = outboundMW(h)
 		if vt.Transforms != nil {
-			h = vt.Transforms.RequestMiddleware()(h)
+			h = &transform.Handler{Transforms: vt.Transforms, Next: h}
 		}
 		entry.Handler = h
 

--- a/pkg/upstream/http/builder.go
+++ b/pkg/upstream/http/builder.go
@@ -51,7 +51,7 @@ func (b *Builder) Build(ctx context.Context, cfg *config.UpstreamConfig, naming 
 	if outboundStrategy == "" {
 		outboundStrategy = "none"
 	}
-	outboundMW, err := pkgmiddleware.New(ctx, "outbound/"+outboundStrategy, &outboundCfg)
+	outboundBuilder, err := pkgmiddleware.New(ctx, "outbound/"+outboundStrategy, &outboundCfg)
 	if err != nil {
 		return nil, fmt.Errorf("build outbound auth for upstream %q: %w", cfg.Name, err)
 	}
@@ -108,7 +108,7 @@ func (b *Builder) Build(ctx context.Context, cfg *config.UpstreamConfig, naming 
 		// Compose the per-tool handler chain:
 		//   TransformHandler → outbound auth → Executor (terminal handler)
 		var h nethttp.Handler = executor
-		h = outboundMW(h)
+		h = outboundBuilder.Build(h)
 		if vt.Transforms != nil {
 			h = &transform.Handler{Transforms: vt.Transforms, Next: h}
 		}

--- a/pkg/upstream/http/refresh.go
+++ b/pkg/upstream/http/refresh.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gaarutyunov/mcp-anything/pkg/openapi"
 	"github.com/gaarutyunov/mcp-anything/pkg/runtime"
 	pkgtelemetry "github.com/gaarutyunov/mcp-anything/pkg/telemetry"
+	"github.com/gaarutyunov/mcp-anything/pkg/transform"
 	pkgupstream "github.com/gaarutyunov/mcp-anything/pkg/upstream"
 )
 
@@ -345,12 +346,12 @@ func (r *Refresher) buildEntriesFromBytes(ctx context.Context, mergedBytes []byt
 		executor := &Executor{entry: entry}
 		entry.Executor = executor
 
-		// Compose the per-tool middleware chain:
-		//   RequestMiddleware (transform) → outbound auth → Executor (terminal handler)
+		// Compose the per-tool handler chain:
+		//   TransformHandler → outbound auth → Executor (terminal handler)
 		var h nethttp.Handler = executor
 		h = outboundMW(h)
 		if vt.Transforms != nil {
-			h = vt.Transforms.RequestMiddleware()(h)
+			h = &transform.Handler{Transforms: vt.Transforms, Next: h}
 		}
 		entry.Handler = h
 

--- a/pkg/upstream/http/refresh.go
+++ b/pkg/upstream/http/refresh.go
@@ -305,7 +305,7 @@ func (r *Refresher) buildEntriesFromBytes(ctx context.Context, mergedBytes []byt
 	if outboundStrategy == "" {
 		outboundStrategy = "none"
 	}
-	outboundMW, err := pkgmiddleware.New(ctx, "outbound/"+outboundStrategy, &outboundCfg)
+	outboundBuilder, err := pkgmiddleware.New(ctx, "outbound/"+outboundStrategy, &outboundCfg)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("building outbound auth: %w", err)
 	}
@@ -349,7 +349,7 @@ func (r *Refresher) buildEntriesFromBytes(ctx context.Context, mergedBytes []byt
 		// Compose the per-tool handler chain:
 		//   TransformHandler → outbound auth → Executor (terminal handler)
 		var h nethttp.Handler = executor
-		h = outboundMW(h)
+		h = outboundBuilder.Build(h)
 		if vt.Transforms != nil {
 			h = &transform.Handler{Transforms: vt.Transforms, Next: h}
 		}


### PR DESCRIPTION
Removes the standalone `inbound.ValidatorMiddleware` and `outbound.Middleware` transformer functions. Introduces embeddable base structs (`ValidatorBase`, `ProviderBase`) that provide `Middleware()` methods directly on each concrete type, following the same pattern as `transform.CompiledTransforms.RequestMiddleware()`.

Closes #133

Generated with [Claude Code](https://claude.ai/code)