### PR TITLE
fix: use -coverprofile for unit tests so coverage artifact is uploaded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ vet:
 
 test:
 	mkdir -p $(COVERAGE_DIR)/unit
-	GOCOVERDIR=$(COVERAGE_DIR)/unit go test $(GOFLAGS) -cover -coverpkg=./... -count=1 ./...
+	go test $(GOFLAGS) -cover -coverpkg=./... -count=1 -coverprofile=$(COVERAGE_DIR)/unit/coverage.out ./...
 
 integration:
 	mkdir -p $(COVERAGE_DIR)/integration
-	GOCOVERDIR=$(COVERAGE_DIR)/integration COVERAGE_DIR=$(COVERAGE_DIR)/integration go test $(GOFLAGS) -tags integration -cover -coverpkg=./... -count=1 -timeout $(INTEGRATION_TIMEOUT) ./tests/integration/...
+	COVERAGE_DIR=$(COVERAGE_DIR)/integration go test $(GOFLAGS) -tags integration -count=1 -timeout $(INTEGRATION_TIMEOUT) ./tests/integration/...
 
 e2e:
 	go test $(GOFLAGS) -tags e2e -count=1 -timeout $(INTEGRATION_TIMEOUT) $(E2E_RUN_FLAG) ./tests/e2e/...
@@ -54,8 +54,10 @@ check: lint vet test build build-operator treeshake
 
 cover-merge:
 	mkdir -p $(COVERAGE_DIR)/merged
-	go tool covdata merge -i $(COVERAGE_DIR)/unit,$(COVERAGE_DIR)/integration -o $(COVERAGE_DIR)/merged
-	go tool covdata textfmt -i $(COVERAGE_DIR)/merged -o $(COVERAGE_DIR)/coverage.out
+	cp $(COVERAGE_DIR)/unit/coverage.out $(COVERAGE_DIR)/coverage.out
+	go tool covdata textfmt -i $(COVERAGE_DIR)/integration -o $(COVERAGE_DIR)/merged/integration.out 2>/dev/null \
+		&& tail -n +2 $(COVERAGE_DIR)/merged/integration.out >> $(COVERAGE_DIR)/coverage.out \
+		|| true
 
 cover-report: cover-merge
 	go tool cover -func=$(COVERAGE_DIR)/coverage.out


### PR DESCRIPTION
Fixes #128

## Summary

- `make test`: switch to `-coverprofile=coverage/unit/coverage.out` so the artifact upload step finds the file
- `make integration`: remove non-working `GOCOVERDIR` and `-cover` from the test process; proxy container coverage via bind-mount is unaffected
- `make cover-merge`: copy unit text profile + optionally append integration binary covdata converted to text

Generated with [Claude Code](https://claude.ai/code)) | [`claude/issue-128-20260417-0725`](https://github.com/gaarutyunov/mcp-anything/tree/claude/issue-128-20260417-0725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test coverage infrastructure to improve consistency and reliability of coverage reporting across unit and integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->